### PR TITLE
feat(vim): add yank and paste with internal register

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ocv update
 ## Supported motions
 
 `h` `j` `k` `l` `w` `b` `e` `W` `B` `E` `0` `^` `_` `$` `gg` `G`
-`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J`
+`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J` `yy` `yw` `p` `P`
 `f` `F` `t` `T` `;` `,`
 `Ctrl+e` `Ctrl+y` `Ctrl+d` `Ctrl+u` `Ctrl+f` `Ctrl+b`
 

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -27,7 +27,11 @@ import {
   moveWordPrev,
   openLineAbove,
   openLineBelow,
+  pasteAfter,
+  pasteBefore,
   substituteLine,
+  yankLine,
+  yankWord,
 } from "./vim-motions"
 
 export type VimEvent = {
@@ -100,7 +104,8 @@ export function createVimHandler(input: {
 
       if (input.state.pending() === "c") {
         if (key === "c" && !event.shift && !hasModifier(event)) {
-          substituteLine(input.textarea())
+          const reg = substituteLine(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           input.state.setMode("insert")
           event.preventDefault()
@@ -108,7 +113,8 @@ export function createVimHandler(input: {
         }
 
         if (key === "w" && !event.shift && !hasModifier(event)) {
-          deleteWord(input.textarea())
+          const reg = deleteWord(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           input.state.setMode("insert")
           event.preventDefault()
@@ -125,14 +131,41 @@ export function createVimHandler(input: {
 
       if (input.state.pending() === "d") {
         if (key === "d" && !event.shift && !hasModifier(event)) {
-          deleteLine(input.textarea())
+          const reg = deleteLine(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           event.preventDefault()
           return true
         }
 
         if (key === "w" && !event.shift && !hasModifier(event)) {
-          deleteWord(input.textarea())
+          const reg = deleteWord(input.textarea())
+          if (reg) input.state.setRegister(reg)
+          input.state.clearPending()
+          event.preventDefault()
+          return true
+        }
+
+        if (hasModifier(event)) {
+          input.state.clearPending()
+          return false
+        }
+
+        input.state.clearPending()
+      }
+
+      if (input.state.pending() === "y") {
+        if (key === "y" && !event.shift && !hasModifier(event)) {
+          const reg = yankLine(input.textarea())
+          if (reg) input.state.setRegister(reg)
+          input.state.clearPending()
+          event.preventDefault()
+          return true
+        }
+
+        if (key === "w" && !event.shift && !hasModifier(event)) {
+          const reg = yankWord(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           event.preventDefault()
           return true
@@ -190,6 +223,24 @@ export function createVimHandler(input: {
         return true
       }
 
+      if (key === "y" && !event.shift && !hasModifier(event)) {
+        input.state.setPending("y")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "p" && !event.shift && !hasModifier(event)) {
+        pasteAfter(input.textarea(), input.state.register())
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "p") && !hasModifier(event)) {
+        pasteBefore(input.textarea(), input.state.register())
+        event.preventDefault()
+        return true
+      }
+
       if (key === "f" && !event.shift && !hasModifier(event)) {
         input.state.setPending("f")
         event.preventDefault()
@@ -230,7 +281,8 @@ export function createVimHandler(input: {
 
       if (isShifted(event, "s") && !hasModifier(event)) {
         input.state.clearPending()
-        substituteLine(input.textarea())
+        const reg = substituteLine(input.textarea())
+        if (reg) input.state.setRegister(reg)
         input.state.setMode("insert")
         event.preventDefault()
         return true
@@ -327,7 +379,8 @@ export function createVimHandler(input: {
       }
 
       if (key === "x" && !event.shift && !hasModifier(event)) {
-        deleteUnderCursor(input.textarea())
+        const reg = deleteUnderCursor(input.textarea())
+        if (reg) input.state.setRegister(reg)
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -1,4 +1,5 @@
 import type { TextareaRenderable } from "@opentui/core"
+import type { VimRegister } from "./vim-state"
 
 function lineStart(text: string, offset: number) {
   if (offset <= 0) return 0
@@ -209,41 +210,48 @@ export function openLineAbove(textarea: TextareaRenderable) {
   textarea.cursorOffset = start
 }
 
-export function deleteUnderCursor(textarea: TextareaRenderable) {
+export function deleteUnderCursor(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
   const startOffset = textarea.cursorOffset
   const end = lineEnd(text, startOffset)
-  if (startOffset >= end) return
+  if (startOffset >= end) return null
+  const yanked = text[startOffset]
   deleteOffsets(textarea, startOffset, startOffset + 1)
+  return { text: yanked, linewise: false }
 }
 
-export function deleteWord(textarea: TextareaRenderable) {
+export function deleteWord(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
   const startOffset = textarea.cursorOffset
   const endOffset = nextWordStart(text, startOffset, false)
+  if (endOffset <= startOffset) return null
+  const yanked = text.slice(startOffset, endOffset)
   deleteOffsets(textarea, startOffset, endOffset)
+  return { text: yanked, linewise: false }
 }
 
-export function deleteLine(textarea: TextareaRenderable) {
+export function deleteLine(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
-  if (!text.length) return
+  if (!text.length) return null
 
   const offset = textarea.cursorOffset
   const start = lineStart(text, offset)
   const end = lineEnd(text, offset)
+  const yanked = text.slice(start, end)
 
   if (end < text.length) {
     deleteOffsets(textarea, start, end + 1)
-    return
+    return { text: yanked, linewise: true }
   }
 
   if (start > 0) {
     deleteOffsets(textarea, start - 1, end)
     textarea.cursorOffset = lineStart(textarea.plainText, textarea.cursorOffset)
-    return
+    return { text: yanked, linewise: true }
   }
 
   deleteOffsets(textarea, start, end)
+  return { text: yanked, linewise: true }
 }
 
 export function findChar(textarea: TextareaRenderable, char: string, forward: boolean, till = false, repeat = false) {
@@ -282,9 +290,56 @@ export function joinLines(textarea: TextareaRenderable) {
   textarea.cursorOffset = end
 }
 
-export function substituteLine(textarea: TextareaRenderable) {
+export function substituteLine(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
   const start = lineStart(text, textarea.cursorOffset)
   const end = lineEnd(text, textarea.cursorOffset)
+  if (end <= start) return null
+  const yanked = text.slice(start, end)
   deleteOffsets(textarea, start, end)
+  return { text: yanked, linewise: true }
+}
+
+export function yankLine(textarea: TextareaRenderable): VimRegister {
+  const text = textarea.plainText
+  const start = lineStart(text, textarea.cursorOffset)
+  const end = lineEnd(text, textarea.cursorOffset)
+  return { text: text.slice(start, end), linewise: true }
+}
+
+export function yankWord(textarea: TextareaRenderable): VimRegister {
+  const text = textarea.plainText
+  const start = textarea.cursorOffset
+  const end = nextWordStart(text, start, false)
+  if (end <= start) return null
+  return { text: text.slice(start, end), linewise: false }
+}
+
+export function pasteAfter(textarea: TextareaRenderable, reg: VimRegister) {
+  if (!reg) return
+  if (reg.linewise) {
+    const text = textarea.plainText
+    const end = lineEnd(text, textarea.cursorOffset)
+    textarea.cursorOffset = end
+    textarea.insertText("\n" + reg.text)
+    textarea.cursorOffset = end + 1
+    return
+  }
+  textarea.cursorOffset = Math.min(textarea.cursorOffset + 1, textarea.plainText.length)
+  textarea.insertText(reg.text)
+  textarea.cursorOffset = textarea.cursorOffset - 1
+}
+
+export function pasteBefore(textarea: TextareaRenderable, reg: VimRegister) {
+  if (!reg) return
+  if (reg.linewise) {
+    const text = textarea.plainText
+    const start = lineStart(text, textarea.cursorOffset)
+    textarea.cursorOffset = start
+    textarea.insertText(reg.text + "\n")
+    textarea.cursorOffset = start
+    return
+  }
+  textarea.insertText(reg.text)
+  textarea.cursorOffset = textarea.cursorOffset - 1
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,13 +1,15 @@
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 
 export type VimMode = "normal" | "insert"
-export type VimPending = "" | "c" | "d" | "g" | "f" | "F" | "t" | "T"
+export type VimPending = "" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y"
 export type VimFind = { char: string; forward: boolean; till: boolean } | null
+export type VimRegister = { text: string; linewise: boolean } | null
 
 export function createVimState(input: { enabled: Accessor<boolean>; initial?: Accessor<VimMode | undefined> }) {
   const [mode, setMode] = createSignal<VimMode>(input.initial?.() ?? "insert")
   const [pending, setPending] = createSignal<VimPending>("")
   const [lastFind, setLastFind] = createSignal<VimFind>(null)
+  const [register, setRegister] = createSignal<VimRegister>(null)
 
   function clearPending() {
     if (pending()) setPending("")
@@ -36,6 +38,8 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
     clearPending,
     lastFind,
     setLastFind,
+    register,
+    setRegister,
     reset() {
       clearPending()
       setMode("insert")

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -88,8 +88,9 @@ function createHandler(
   const textarea = createTextarea(text)
   const [enabled] = createSignal(options?.enabled ?? true)
   const [mode, setMode] = createSignal<"normal" | "insert">(options?.mode ?? "normal")
-  const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "f" | "F" | "t" | "T">("")
+  const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y">("")
   const [lastFind, setLastFind] = createSignal<{ char: string; forward: boolean; till: boolean } | null>(null)
+  const [register, setRegister] = createSignal<{ text: string; linewise: boolean } | null>(null)
   const scrollCalls: VimScroll[] = []
   const jumpCalls: VimJump[] = []
 
@@ -102,10 +103,7 @@ function createHandler(
     setMode(next)
   }
 
-  const state: Pick<
-    ReturnType<typeof createVimState>,
-    "mode" | "setMode" | "reset" | "isInsert" | "pending" | "setPending" | "clearPending" | "lastFind" | "setLastFind"
-  > = {
+  const state: ReturnType<typeof createVimState> = {
     mode,
     setMode: changeMode,
     pending,
@@ -113,12 +111,14 @@ function createHandler(
     clearPending,
     lastFind,
     setLastFind,
+    register,
+    setRegister,
     reset() {
       clearPending()
       setMode("insert")
     },
     isInsert: () => mode() === "insert",
-  }
+  } as ReturnType<typeof createVimState>
   const handler = createVimHandler({
     enabled,
     state,
@@ -1007,6 +1007,179 @@ describe("vim motion handler", () => {
 
     ctx.handler.handleKey(createEvent(",").event)
     expect(ctx.textarea.cursorOffset).toBe(3)
+  })
+
+  test("yy yanks current line into register", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "two", linewise: true })
+    expect(ctx.textarea.cursorOffset).toBe(5)
+    expect(ctx.textarea.plainText).toBe("one\ntwo\nthree")
+  })
+
+  test("yw yanks word into register", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("w").event)
+    expect(ctx.state.register()).toEqual({ text: "hello ", linewise: false })
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.textarea.plainText).toBe("hello world")
+  })
+
+  test("p pastes linewise below current line", () => {
+    const ctx = createHandler("one\ntwo")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("y").event)
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("one\none\ntwo")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("P pastes linewise above current line", () => {
+    const ctx = createHandler("one\ntwo")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("y").event)
+
+    ctx.handler.handleKey(createEvent("P").event)
+    expect(ctx.textarea.plainText).toBe("one\ntwo\ntwo")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("p pastes characterwise after cursor", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("w").event)
+
+    ctx.textarea.cursorOffset = 6
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("hello whello orld")
+    expect(ctx.textarea.cursorOffset).toBe(12)
+  })
+
+  test("P pastes characterwise before cursor", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("w").event)
+
+    ctx.textarea.cursorOffset = 6
+    ctx.handler.handleKey(createEvent("P").event)
+    expect(ctx.textarea.plainText).toBe("hello hello world")
+    expect(ctx.textarea.cursorOffset).toBe(11)
+  })
+
+  test("p with empty register is no-op", () => {
+    const ctx = createHandler("hello")
+    ctx.textarea.cursorOffset = 2
+
+    const p = createEvent("p")
+    expect(ctx.handler.handleKey(p.event)).toBe(true)
+    expect(p.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("hello")
+    expect(ctx.textarea.cursorOffset).toBe(2)
+  })
+
+  test("yy then p multiple times", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("y").event)
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("abc\nabc")
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("abc\nabc\nabc")
+  })
+
+  test("dd populates register", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.state.register()).toEqual({ text: "two", linewise: true })
+  })
+
+  test("dw populates register", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("w").event)
+    expect(ctx.state.register()).toEqual({ text: "hello ", linewise: false })
+  })
+
+  test("x populates register", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("x").event)
+    expect(ctx.state.register()).toEqual({ text: "b", linewise: false })
+  })
+
+  test("pending y clears on escape", () => {
+    const ctx = createHandler("hello")
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    ctx.handler.handleKey(createEvent("escape").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toBe(null)
+  })
+
+  test("pending y clears on invalid key", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 2
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    ctx.handler.handleKey(createEvent("h").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+  })
+
+  test("pending y clears on modifier key", () => {
+    const ctx = createHandler("abc")
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    const mod = createEvent("j", { ctrl: true })
+    expect(ctx.handler.handleKey(mod.event)).toBe(false)
+    expect(mod.prevented()).toBe(false)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("dd then p pastes deleted line below", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe("one\nthree")
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("one\nthree\ntwo")
   })
 
   test("pending d clears on escape", () => {

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -410,7 +410,7 @@ Enable it from the command palette or in your config.
 
 **Movement:** `h`, `j`, `k`, `l`, `0`, `^`/`_`, `$`; `w`, `b`, `e`, `W`, `B`, `E`; `f`, `F`, `t`, `T`, `;`, `,`
 
-**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`
+**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`; `yy`, `yw`, `p`, `P`
 
 **Navigation:** `gg`, `G`
 


### PR DESCRIPTION
Part of #5
Add yank/paste (`yy`, `yw`, `p`, `P`) with internal register; deletes auto-populate