### PR TITLE
feat(vim): visual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ocv update
 ## Supported motions
 
 `h` `j` `k` `l` `w` `b` `e` `W` `B` `E` `0` `^` `_` `$` `gg` `G`
-`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J` `yy` `yw` `p` `P` `v`
+`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J` `yy` `yw` `p` `P` `v` `V`
 `f` `F` `t` `T` `;` `,`
 `Ctrl+e` `Ctrl+y` `Ctrl+d` `Ctrl+u` `Ctrl+f` `Ctrl+b`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ocv update
 ## Supported motions
 
 `h` `j` `k` `l` `w` `b` `e` `W` `B` `E` `0` `^` `_` `$` `gg` `G`
-`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J` `yy` `yw` `p` `P`
+`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J` `yy` `yw` `p` `P` `v`
 `f` `F` `t` `T` `;` `,`
 `Ctrl+e` `Ctrl+y` `Ctrl+d` `Ctrl+u` `Ctrl+f` `Ctrl+b`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ocv update
 ## Supported motions
 
 `h` `j` `k` `l` `w` `b` `e` `W` `B` `E` `0` `^` `_` `$` `gg` `G`
-`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J`
+`i` `I` `a` `A` `o` `O` `x` `dd` `dw` `cc` `cw` `S` `J` `yy` `yw` `p` `P`
 `f` `F` `t` `T` `;` `,`
 `Ctrl+e` `Ctrl+y` `Ctrl+d` `Ctrl+u` `Ctrl+f` `Ctrl+b`
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1139,7 +1139,15 @@ export function Prompt(props: PromptProps) {
         <box flexDirection="row" justifyContent="space-between">
           <Show when={vimIndicator()}>
             {(indicator) => (
-              <text fg={indicator() === "INSERT" ? local.agent.color(local.agent.current().name) : theme.textMuted}>
+              <text
+                fg={
+                  indicator() === "INSERT"
+                    ? local.agent.color(local.agent.current().name)
+                    : indicator() === "VISUAL"
+                      ? theme.warning
+                      : theme.textMuted
+                }
+              >
                 -- {indicator()} --
               </text>
             )}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,4 +1,4 @@
-import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, t, dim, fg } from "@opentui/core"
+import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, TextAttributes, t, dim, fg } from "@opentui/core"
 import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
@@ -1144,9 +1144,10 @@ export function Prompt(props: PromptProps) {
                   indicator() === "INSERT"
                     ? local.agent.color(local.agent.current().name)
                     : indicator() === "VISUAL" || indicator() === "V-LINE"
-                      ? theme.warning
+                      ? theme.text
                       : theme.textMuted
                 }
+                attributes={indicator() === "VISUAL" || indicator() === "V-LINE" ? TextAttributes.BOLD : undefined}
               >
                 -- {indicator()} --
               </text>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1143,7 +1143,7 @@ export function Prompt(props: PromptProps) {
                 fg={
                   indicator() === "INSERT"
                     ? local.agent.color(local.agent.current().name)
-                    : indicator() === "VISUAL"
+                    : indicator() === "VISUAL" || indicator() === "V-LINE"
                       ? theme.warning
                       : theme.textMuted
                 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -101,8 +101,10 @@ export function createVimHandler(input: {
     }
 
     if (input.state.isVisual()) {
+      const lw = input.state.isVisualLine()
+
       if ((key === "d" || key === "x") && !hasModifier(event)) {
-        const reg = deleteSelection(input.textarea())
+        const reg = deleteSelection(input.textarea(), lw)
         if (reg) input.state.setRegister(reg)
         clearSelection(input.textarea())
         input.state.setMode("normal")
@@ -111,7 +113,7 @@ export function createVimHandler(input: {
       }
 
       if (key === "y" && !event.shift && !hasModifier(event)) {
-        const reg = yankSelection(input.textarea())
+        const reg = yankSelection(input.textarea(), lw)
         if (reg) input.state.setRegister(reg)
         clearSelection(input.textarea())
         input.state.setMode("normal")
@@ -120,7 +122,7 @@ export function createVimHandler(input: {
       }
 
       if (key === "c" && !event.shift && !hasModifier(event)) {
-        const reg = deleteSelection(input.textarea())
+        const reg = deleteSelection(input.textarea(), lw)
         if (reg) input.state.setRegister(reg)
         clearSelection(input.textarea())
         input.state.setMode("insert")
@@ -142,8 +144,25 @@ export function createVimHandler(input: {
       }
 
       if (key === "v" && !event.shift && !hasModifier(event)) {
+        if (lw) {
+          input.state.setMode("visual")
+          event.preventDefault()
+          return true
+        }
         clearSelection(input.textarea())
         input.state.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "v") && !hasModifier(event)) {
+        if (lw) {
+          clearSelection(input.textarea())
+          input.state.setMode("normal")
+          event.preventDefault()
+          return true
+        }
+        input.state.setMode("visual-line")
         event.preventDefault()
         return true
       }
@@ -343,6 +362,14 @@ export function createVimHandler(input: {
       return true
     }
 
+    if (isShifted(event, "v") && !hasModifier(event)) {
+      input.state.setAnchor(input.textarea().cursorOffset)
+      input.state.setMode("visual-line")
+      syncSelection(input.textarea(), input.textarea().cursorOffset, true)
+      event.preventDefault()
+      return true
+    }
+
     if (key === "i" && !event.shift && !hasModifier(event)) {
       input.state.setMode("insert")
       event.preventDefault()
@@ -505,7 +532,7 @@ export function createVimHandler(input: {
 
       if (result && input.state.isVisual()) {
         const a = input.state.anchor()
-        if (a !== null) syncSelection(input.textarea(), a)
+        if (a !== null) syncSelection(input.textarea(), a, input.state.isVisualLine())
       }
 
       return result

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -27,7 +27,11 @@ import {
   moveWordPrev,
   openLineAbove,
   openLineBelow,
+  pasteAfter,
+  pasteBefore,
   substituteLine,
+  yankLine,
+  yankWord,
 } from "./vim-motions"
 
 export type VimEvent = {
@@ -100,7 +104,8 @@ export function createVimHandler(input: {
 
       if (input.state.pending() === "c") {
         if (key === "c" && !event.shift && !hasModifier(event)) {
-          substituteLine(input.textarea())
+          const reg = substituteLine(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           input.state.setMode("insert")
           event.preventDefault()
@@ -108,7 +113,8 @@ export function createVimHandler(input: {
         }
 
         if (key === "w" && !event.shift && !hasModifier(event)) {
-          deleteWord(input.textarea())
+          const reg = deleteWord(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           input.state.setMode("insert")
           event.preventDefault()
@@ -125,14 +131,41 @@ export function createVimHandler(input: {
 
       if (input.state.pending() === "d") {
         if (key === "d" && !event.shift && !hasModifier(event)) {
-          deleteLine(input.textarea())
+          const reg = deleteLine(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           event.preventDefault()
           return true
         }
 
         if (key === "w" && !event.shift && !hasModifier(event)) {
-          deleteWord(input.textarea())
+          const reg = deleteWord(input.textarea())
+          if (reg) input.state.setRegister(reg)
+          input.state.clearPending()
+          event.preventDefault()
+          return true
+        }
+
+        if (hasModifier(event)) {
+          input.state.clearPending()
+          return false
+        }
+
+        input.state.clearPending()
+      }
+
+      if (input.state.pending() === "y") {
+        if (key === "y" && !event.shift && !hasModifier(event)) {
+          const reg = yankLine(input.textarea())
+          if (reg) input.state.setRegister(reg)
+          input.state.clearPending()
+          event.preventDefault()
+          return true
+        }
+
+        if (key === "w" && !event.shift && !hasModifier(event)) {
+          const reg = yankWord(input.textarea())
+          if (reg) input.state.setRegister(reg)
           input.state.clearPending()
           event.preventDefault()
           return true
@@ -190,6 +223,24 @@ export function createVimHandler(input: {
         return true
       }
 
+      if (key === "y" && !event.shift && !hasModifier(event)) {
+        input.state.setPending("y")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "p" && !event.shift && !hasModifier(event)) {
+        pasteAfter(input.textarea(), input.state.register())
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "p") && !hasModifier(event)) {
+        pasteBefore(input.textarea(), input.state.register())
+        event.preventDefault()
+        return true
+      }
+
       if (key === "f" && !event.shift && !hasModifier(event)) {
         input.state.setPending("f")
         event.preventDefault()
@@ -230,7 +281,8 @@ export function createVimHandler(input: {
 
       if (isShifted(event, "s") && !hasModifier(event)) {
         input.state.clearPending()
-        substituteLine(input.textarea())
+        const reg = substituteLine(input.textarea())
+        if (reg) input.state.setRegister(reg)
         input.state.setMode("insert")
         event.preventDefault()
         return true
@@ -327,7 +379,8 @@ export function createVimHandler(input: {
       }
 
       if (key === "x" && !event.shift && !hasModifier(event)) {
-        deleteUnderCursor(input.textarea())
+        const reg = deleteUnderCursor(input.textarea())
+        if (reg) input.state.setRegister(reg)
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -6,7 +6,9 @@ import { vimJump, type VimJump } from "./vim-motion-jump"
 import {
   appendAfterCursor,
   appendLineEnd,
+  clearSelection,
   deleteLine,
+  deleteSelection,
   deleteUnderCursor,
   deleteWord,
   findChar,
@@ -30,7 +32,9 @@ import {
   pasteAfter,
   pasteBefore,
   substituteLine,
+  syncSelection,
   yankLine,
+  yankSelection,
   yankWord,
 } from "./vim-motions"
 
@@ -64,6 +68,427 @@ export function createVimHandler(input: {
     return event.name === key.toUpperCase() || (event.name === key && !!event.shift)
   }
 
+  function dispatch(event: VimEvent, key: string): boolean {
+    const scroll = vimScroll(event)
+    if (scroll) {
+      input.state.clearPending()
+      input.scroll(scroll)
+      event.preventDefault()
+      return true
+    }
+
+    const jump = vimJump(event, input.state)
+    if (jump.handled) {
+      if (jump.action) {
+        input.state.clearPending()
+        input.jump(jump.action)
+      }
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "escape") {
+      if (input.state.isVisual()) {
+        clearSelection(input.textarea())
+        input.state.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+      if (!input.state.pending()) return false
+      input.state.clearPending()
+      event.preventDefault()
+      return true
+    }
+
+    if (input.state.isVisual()) {
+      if ((key === "d" || key === "x") && !hasModifier(event)) {
+        const reg = deleteSelection(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        clearSelection(input.textarea())
+        input.state.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "y" && !event.shift && !hasModifier(event)) {
+        const reg = yankSelection(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        clearSelection(input.textarea())
+        input.state.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "c" && !event.shift && !hasModifier(event)) {
+        const reg = deleteSelection(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        clearSelection(input.textarea())
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "p" && !event.shift && !hasModifier(event)) {
+        const reg = input.state.register()
+        if (reg) {
+          deleteSelection(input.textarea())
+          clearSelection(input.textarea())
+          input.textarea().insertText(reg.text)
+          input.textarea().cursorOffset = input.textarea().cursorOffset - 1
+        }
+        input.state.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "v" && !event.shift && !hasModifier(event)) {
+        clearSelection(input.textarea())
+        input.state.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+    }
+
+    if (input.state.pending() === "c") {
+      if (key === "c" && !event.shift && !hasModifier(event)) {
+        const reg = substituteLine(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        input.state.clearPending()
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "w" && !event.shift && !hasModifier(event)) {
+        const reg = deleteWord(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        input.state.clearPending()
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (hasModifier(event)) {
+        input.state.clearPending()
+        return false
+      }
+
+      input.state.clearPending()
+    }
+
+    if (input.state.pending() === "d") {
+      if (key === "d" && !event.shift && !hasModifier(event)) {
+        const reg = deleteLine(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "w" && !event.shift && !hasModifier(event)) {
+        const reg = deleteWord(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
+
+      if (hasModifier(event)) {
+        input.state.clearPending()
+        return false
+      }
+
+      input.state.clearPending()
+    }
+
+    if (input.state.pending() === "y") {
+      if (key === "y" && !event.shift && !hasModifier(event)) {
+        const reg = yankLine(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "w" && !event.shift && !hasModifier(event)) {
+        const reg = yankWord(input.textarea())
+        if (reg) input.state.setRegister(reg)
+        input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
+
+      if (hasModifier(event)) {
+        input.state.clearPending()
+        return false
+      }
+
+      input.state.clearPending()
+    }
+
+    const find = input.state.pending()
+    if (find === "f" || find === "F" || find === "t" || find === "T") {
+      if (isPrintable(event) && !hasModifier(event)) {
+        const forward = find === "f" || find === "t"
+        const till = find === "t" || find === "T"
+        findChar(input.textarea(), key, forward, till)
+        input.state.setLastFind({ char: key, forward, till })
+        input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
+      input.state.clearPending()
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "return" && !hasModifier(event)) {
+      input.submit()
+      input.state.clearPending()
+      event.preventDefault()
+      return true
+    }
+
+    if ((key === "/" || key === "@") && !hasModifier(event)) {
+      if (input.autocomplete?.() && input.textarea().cursorOffset === 0 && input.textarea().plainText.length === 0) {
+        input.state.setMode("insert")
+        return false
+      }
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "c" && !event.shift && !hasModifier(event)) {
+      input.state.setPending("c")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "d" && !event.shift && !hasModifier(event)) {
+      input.state.setPending("d")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "y" && !event.shift && !hasModifier(event)) {
+      input.state.setPending("y")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "p" && !event.shift && !hasModifier(event)) {
+      pasteAfter(input.textarea(), input.state.register())
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "p") && !hasModifier(event)) {
+      pasteBefore(input.textarea(), input.state.register())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "f" && !event.shift && !hasModifier(event)) {
+      input.state.setPending("f")
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "f") && !hasModifier(event)) {
+      input.state.setPending("F")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "t" && !event.shift && !hasModifier(event)) {
+      input.state.setPending("t")
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "t") && !hasModifier(event)) {
+      input.state.setPending("T")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === ";" && !event.shift && !hasModifier(event)) {
+      const last = input.state.lastFind()
+      if (last) findChar(input.textarea(), last.char, last.forward, last.till, true)
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "," && !event.shift && !hasModifier(event)) {
+      const last = input.state.lastFind()
+      if (last) findChar(input.textarea(), last.char, !last.forward, last.till, true)
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "s") && !hasModifier(event)) {
+      input.state.clearPending()
+      const reg = substituteLine(input.textarea())
+      if (reg) input.state.setRegister(reg)
+      input.state.setMode("insert")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "v" && !event.shift && !hasModifier(event)) {
+      input.state.setAnchor(input.textarea().cursorOffset)
+      input.state.setMode("visual")
+      syncSelection(input.textarea(), input.textarea().cursorOffset)
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "i" && !event.shift && !hasModifier(event)) {
+      input.state.setMode("insert")
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "i") && !hasModifier(event)) {
+      insertLineStart(input.textarea())
+      input.state.setMode("insert")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "a" && !event.shift && !hasModifier(event)) {
+      appendAfterCursor(input.textarea())
+      input.state.setMode("insert")
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "a") && !hasModifier(event)) {
+      appendLineEnd(input.textarea())
+      input.state.setMode("insert")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "o" && !event.shift && !hasModifier(event)) {
+      openLineBelow(input.textarea())
+      input.state.setMode("insert")
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "o") && !hasModifier(event)) {
+      openLineAbove(input.textarea())
+      input.state.setMode("insert")
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "h" && !event.shift && !hasModifier(event)) {
+      moveLeft(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "l" && !event.shift && !hasModifier(event)) {
+      moveRight(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "j") && !hasModifier(event)) {
+      input.state.clearPending()
+      joinLines(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "j" && !event.shift && !hasModifier(event)) {
+      moveLineDown(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "k" && !event.shift && !hasModifier(event)) {
+      moveLineUp(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "0" && !event.shift && !hasModifier(event)) {
+      moveLineBeginning(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if ((key === "^" || key === "_") && !hasModifier(event)) {
+      moveFirstNonWhitespace(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "$" && !hasModifier(event)) {
+      moveLineEnd(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "x" && !event.shift && !hasModifier(event)) {
+      const reg = deleteUnderCursor(input.textarea())
+      if (reg) input.state.setRegister(reg)
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "w" && !event.shift && !hasModifier(event)) {
+      moveWordNext(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "b" && !event.shift && !hasModifier(event)) {
+      moveWordPrev(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "e" && !event.shift && !hasModifier(event)) {
+      moveWordEnd(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "w") && !hasModifier(event)) {
+      moveBigWordNext(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "b") && !hasModifier(event)) {
+      moveBigWordPrev(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (isShifted(event, "e") && !hasModifier(event)) {
+      moveBigWordEnd(input.textarea())
+      event.preventDefault()
+      return true
+    }
+
+    if (key === "backspace" || key === "delete") {
+      event.preventDefault()
+      return true
+    }
+
+    if (isPrintable(event) && !hasModifier(event)) {
+      event.preventDefault()
+      return true
+    }
+
+    return false
+  }
+
   return {
     handleKey(event: VimEvent) {
       if (!input.enabled()) return false
@@ -76,362 +501,14 @@ export function createVimHandler(input: {
       }
 
       const key = event.name ?? ""
+      const result = dispatch(event, key)
 
-      const scroll = vimScroll(event)
-      if (scroll) {
-        input.state.clearPending()
-        input.scroll(scroll)
-        event.preventDefault()
-        return true
+      if (result && input.state.isVisual()) {
+        const a = input.state.anchor()
+        if (a !== null) syncSelection(input.textarea(), a)
       }
 
-      const jump = vimJump(event, input.state)
-      if (jump.handled) {
-        if (jump.action) {
-          input.state.clearPending()
-          input.jump(jump.action)
-        }
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "escape") {
-        if (!input.state.pending()) return false
-        input.state.clearPending()
-        event.preventDefault()
-        return true
-      }
-
-      if (input.state.pending() === "c") {
-        if (key === "c" && !event.shift && !hasModifier(event)) {
-          const reg = substituteLine(input.textarea())
-          if (reg) input.state.setRegister(reg)
-          input.state.clearPending()
-          input.state.setMode("insert")
-          event.preventDefault()
-          return true
-        }
-
-        if (key === "w" && !event.shift && !hasModifier(event)) {
-          const reg = deleteWord(input.textarea())
-          if (reg) input.state.setRegister(reg)
-          input.state.clearPending()
-          input.state.setMode("insert")
-          event.preventDefault()
-          return true
-        }
-
-        if (hasModifier(event)) {
-          input.state.clearPending()
-          return false
-        }
-
-        input.state.clearPending()
-      }
-
-      if (input.state.pending() === "d") {
-        if (key === "d" && !event.shift && !hasModifier(event)) {
-          const reg = deleteLine(input.textarea())
-          if (reg) input.state.setRegister(reg)
-          input.state.clearPending()
-          event.preventDefault()
-          return true
-        }
-
-        if (key === "w" && !event.shift && !hasModifier(event)) {
-          const reg = deleteWord(input.textarea())
-          if (reg) input.state.setRegister(reg)
-          input.state.clearPending()
-          event.preventDefault()
-          return true
-        }
-
-        if (hasModifier(event)) {
-          input.state.clearPending()
-          return false
-        }
-
-        input.state.clearPending()
-      }
-
-      if (input.state.pending() === "y") {
-        if (key === "y" && !event.shift && !hasModifier(event)) {
-          const reg = yankLine(input.textarea())
-          if (reg) input.state.setRegister(reg)
-          input.state.clearPending()
-          event.preventDefault()
-          return true
-        }
-
-        if (key === "w" && !event.shift && !hasModifier(event)) {
-          const reg = yankWord(input.textarea())
-          if (reg) input.state.setRegister(reg)
-          input.state.clearPending()
-          event.preventDefault()
-          return true
-        }
-
-        if (hasModifier(event)) {
-          input.state.clearPending()
-          return false
-        }
-
-        input.state.clearPending()
-      }
-
-      const find = input.state.pending()
-      if (find === "f" || find === "F" || find === "t" || find === "T") {
-        if (isPrintable(event) && !hasModifier(event)) {
-          const forward = find === "f" || find === "t"
-          const till = find === "t" || find === "T"
-          findChar(input.textarea(), key, forward, till)
-          input.state.setLastFind({ char: key, forward, till })
-          input.state.clearPending()
-          event.preventDefault()
-          return true
-        }
-        input.state.clearPending()
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "return" && !hasModifier(event)) {
-        input.submit()
-        input.state.clearPending()
-        event.preventDefault()
-        return true
-      }
-
-      if ((key === "/" || key === "@") && !hasModifier(event)) {
-        if (input.autocomplete?.() && input.textarea().cursorOffset === 0 && input.textarea().plainText.length === 0) {
-          input.state.setMode("insert")
-          return false
-        }
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "c" && !event.shift && !hasModifier(event)) {
-        input.state.setPending("c")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "d" && !event.shift && !hasModifier(event)) {
-        input.state.setPending("d")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "y" && !event.shift && !hasModifier(event)) {
-        input.state.setPending("y")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "p" && !event.shift && !hasModifier(event)) {
-        pasteAfter(input.textarea(), input.state.register())
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "p") && !hasModifier(event)) {
-        pasteBefore(input.textarea(), input.state.register())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "f" && !event.shift && !hasModifier(event)) {
-        input.state.setPending("f")
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "f") && !hasModifier(event)) {
-        input.state.setPending("F")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "t" && !event.shift && !hasModifier(event)) {
-        input.state.setPending("t")
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "t") && !hasModifier(event)) {
-        input.state.setPending("T")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === ";" && !event.shift && !hasModifier(event)) {
-        const last = input.state.lastFind()
-        if (last) findChar(input.textarea(), last.char, last.forward, last.till, true)
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "," && !event.shift && !hasModifier(event)) {
-        const last = input.state.lastFind()
-        if (last) findChar(input.textarea(), last.char, !last.forward, last.till, true)
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "s") && !hasModifier(event)) {
-        input.state.clearPending()
-        const reg = substituteLine(input.textarea())
-        if (reg) input.state.setRegister(reg)
-        input.state.setMode("insert")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "i" && !event.shift && !hasModifier(event)) {
-        input.state.setMode("insert")
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "i") && !hasModifier(event)) {
-        insertLineStart(input.textarea())
-        input.state.setMode("insert")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "a" && !event.shift && !hasModifier(event)) {
-        appendAfterCursor(input.textarea())
-        input.state.setMode("insert")
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "a") && !hasModifier(event)) {
-        appendLineEnd(input.textarea())
-        input.state.setMode("insert")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "o" && !event.shift && !hasModifier(event)) {
-        openLineBelow(input.textarea())
-        input.state.setMode("insert")
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "o") && !hasModifier(event)) {
-        openLineAbove(input.textarea())
-        input.state.setMode("insert")
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "h" && !event.shift && !hasModifier(event)) {
-        moveLeft(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "l" && !event.shift && !hasModifier(event)) {
-        moveRight(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "j") && !hasModifier(event)) {
-        input.state.clearPending()
-        joinLines(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "j" && !event.shift && !hasModifier(event)) {
-        moveLineDown(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "k" && !event.shift && !hasModifier(event)) {
-        moveLineUp(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "0" && !event.shift && !hasModifier(event)) {
-        moveLineBeginning(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if ((key === "^" || key === "_") && !hasModifier(event)) {
-        moveFirstNonWhitespace(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "$" && !hasModifier(event)) {
-        moveLineEnd(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "x" && !event.shift && !hasModifier(event)) {
-        const reg = deleteUnderCursor(input.textarea())
-        if (reg) input.state.setRegister(reg)
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "w" && !event.shift && !hasModifier(event)) {
-        moveWordNext(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "b" && !event.shift && !hasModifier(event)) {
-        moveWordPrev(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "e" && !event.shift && !hasModifier(event)) {
-        moveWordEnd(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "w") && !hasModifier(event)) {
-        moveBigWordNext(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "b") && !hasModifier(event)) {
-        moveBigWordPrev(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (isShifted(event, "e") && !hasModifier(event)) {
-        moveBigWordEnd(input.textarea())
-        event.preventDefault()
-        return true
-      }
-
-      if (key === "backspace" || key === "delete") {
-        event.preventDefault()
-        return true
-      }
-
-      if (isPrintable(event) && !hasModifier(event)) {
-        event.preventDefault()
-        return true
-      }
-
-      return false
+      return result
     },
   }
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -101,10 +101,21 @@ export function createVimHandler(input: {
     }
 
     if (input.state.isVisual()) {
+      const a = input.state.anchor()
       const lw = input.state.isVisualLine()
 
+      if ((key === "i" || key === "a" || key === "o") && !event.shift && !hasModifier(event)) {
+        event.preventDefault()
+        return true
+      }
+
+      if ((isShifted(event, "i") || isShifted(event, "a") || isShifted(event, "o")) && !hasModifier(event)) {
+        event.preventDefault()
+        return true
+      }
+
       if ((key === "d" || key === "x") && !hasModifier(event)) {
-        const reg = deleteSelection(input.textarea(), lw)
+        const reg = deleteSelection(input.textarea(), lw, a ?? undefined)
         if (reg) input.state.setRegister(reg)
         clearSelection(input.textarea())
         input.state.setMode("normal")
@@ -113,7 +124,7 @@ export function createVimHandler(input: {
       }
 
       if (key === "y" && !event.shift && !hasModifier(event)) {
-        const reg = yankSelection(input.textarea(), lw)
+        const reg = yankSelection(input.textarea(), lw, a ?? undefined)
         if (reg) input.state.setRegister(reg)
         clearSelection(input.textarea())
         input.state.setMode("normal")
@@ -122,7 +133,7 @@ export function createVimHandler(input: {
       }
 
       if (key === "c" && !event.shift && !hasModifier(event)) {
-        const reg = deleteSelection(input.textarea(), lw)
+        const reg = deleteSelection(input.textarea(), lw, a ?? undefined)
         if (reg) input.state.setRegister(reg)
         clearSelection(input.textarea())
         input.state.setMode("insert")
@@ -133,7 +144,7 @@ export function createVimHandler(input: {
       if (key === "p" && !event.shift && !hasModifier(event)) {
         const reg = input.state.register()
         if (reg) {
-          deleteSelection(input.textarea())
+          deleteSelection(input.textarea(), false, a ?? undefined)
           clearSelection(input.textarea())
           input.textarea().insertText(reg.text)
           input.textarea().cursorOffset = input.textarea().cursorOffset - 1

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
@@ -9,6 +9,7 @@ export function useVimIndicator(input: {
   return createMemo(() => {
     if (!input.enabled() || !input.active()) return
     if (input.state.isInsert()) return "INSERT"
+    if (input.state.isVisualLine()) return "V-LINE"
     if (input.state.isVisual()) return "VISUAL"
     return undefined
   })

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
@@ -9,6 +9,7 @@ export function useVimIndicator(input: {
   return createMemo(() => {
     if (!input.enabled() || !input.active()) return
     if (input.state.isInsert()) return "INSERT"
+    if (input.state.isVisual()) return "VISUAL"
     return undefined
   })
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -344,9 +344,15 @@ export function pasteBefore(textarea: TextareaRenderable, reg: VimRegister) {
   textarea.cursorOffset = textarea.cursorOffset - 1
 }
 
-export function syncSelection(textarea: TextareaRenderable, anchor: number) {
-  const lo = Math.min(anchor, textarea.cursorOffset)
-  const hi = Math.max(anchor + 1, textarea.cursorOffset + 1)
+export function syncSelection(textarea: TextareaRenderable, anchor: number, linewise = false) {
+  const text = textarea.plainText
+  let lo = Math.min(anchor, textarea.cursorOffset)
+  let hi = Math.max(anchor + 1, textarea.cursorOffset + 1)
+  if (linewise) {
+    lo = lineStart(text, lo)
+    hi = lineEnd(text, hi - 1)
+    if (hi < text.length) hi++
+  }
   textarea.editorView.setSelection(lo, hi)
 }
 
@@ -354,17 +360,17 @@ export function clearSelection(textarea: TextareaRenderable) {
   textarea.editorView.resetSelection()
 }
 
-export function deleteSelection(textarea: TextareaRenderable): VimRegister {
+export function deleteSelection(textarea: TextareaRenderable, linewise = false): VimRegister {
   const sel = textarea.editorView.getSelection()
   if (!sel) return null
   const text = textarea.plainText.slice(sel.start, sel.end)
   textarea.editorView.deleteSelectedText()
   textarea.cursorOffset = sel.start
-  return { text, linewise: false }
+  return { text, linewise }
 }
 
-export function yankSelection(textarea: TextareaRenderable): VimRegister {
+export function yankSelection(textarea: TextareaRenderable, linewise = false): VimRegister {
   const sel = textarea.editorView.getSelection()
   if (!sel) return null
-  return { text: textarea.plainText.slice(sel.start, sel.end), linewise: false }
+  return { text: textarea.plainText.slice(sel.start, sel.end), linewise }
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -354,10 +354,19 @@ export function syncSelection(textarea: TextareaRenderable, anchor: number, line
     hi = lineEnd(text, hi - 1)
     if (hi < text.length) hi++
   }
+  const ta = textarea as any
+  const forward = cursor >= anchor
+  textarea.cursorOffset = forward ? lo : hi
+  ta.updateSelectionForMovement(true, true)
+  textarea.cursorOffset = forward ? hi : lo
+  ta.updateSelectionForMovement(true, false)
+  textarea.cursorOffset = cursor
   textarea.editorView.setSelection(lo, hi)
 }
 
 export function clearSelection(textarea: TextareaRenderable) {
+  const ta = textarea as any
+  ta.updateSelectionForMovement(false, true)
   textarea.editorView.resetSelection()
 }
 

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -1,4 +1,5 @@
 import type { TextareaRenderable } from "@opentui/core"
+import type { VimRegister } from "./vim-state"
 
 function lineStart(text: string, offset: number) {
   if (offset <= 0) return 0
@@ -209,41 +210,48 @@ export function openLineAbove(textarea: TextareaRenderable) {
   textarea.cursorOffset = start
 }
 
-export function deleteUnderCursor(textarea: TextareaRenderable) {
+export function deleteUnderCursor(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
   const startOffset = textarea.cursorOffset
   const end = lineEnd(text, startOffset)
-  if (startOffset >= end) return
+  if (startOffset >= end) return null
+  const yanked = text[startOffset]
   deleteOffsets(textarea, startOffset, startOffset + 1)
+  return { text: yanked, linewise: false }
 }
 
-export function deleteWord(textarea: TextareaRenderable) {
+export function deleteWord(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
   const startOffset = textarea.cursorOffset
   const endOffset = nextWordStart(text, startOffset, false)
+  if (endOffset <= startOffset) return null
+  const yanked = text.slice(startOffset, endOffset)
   deleteOffsets(textarea, startOffset, endOffset)
+  return { text: yanked, linewise: false }
 }
 
-export function deleteLine(textarea: TextareaRenderable) {
+export function deleteLine(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
-  if (!text.length) return
+  if (!text.length) return null
 
   const offset = textarea.cursorOffset
   const start = lineStart(text, offset)
   const end = lineEnd(text, offset)
+  const yanked = text.slice(start, end)
 
   if (end < text.length) {
     deleteOffsets(textarea, start, end + 1)
-    return
+    return { text: yanked, linewise: true }
   }
 
   if (start > 0) {
     deleteOffsets(textarea, start - 1, end)
     textarea.cursorOffset = lineStart(textarea.plainText, textarea.cursorOffset)
-    return
+    return { text: yanked, linewise: true }
   }
 
   deleteOffsets(textarea, start, end)
+  return { text: yanked, linewise: true }
 }
 
 export function findChar(textarea: TextareaRenderable, char: string, forward: boolean, till = false, repeat = false) {
@@ -282,9 +290,56 @@ export function joinLines(textarea: TextareaRenderable) {
   textarea.cursorOffset = end
 }
 
-export function substituteLine(textarea: TextareaRenderable) {
+export function substituteLine(textarea: TextareaRenderable): VimRegister {
   const text = textarea.plainText
   const start = lineStart(text, textarea.cursorOffset)
   const end = lineEnd(text, textarea.cursorOffset)
+  if (end <= start) return null
+  const yanked = text.slice(start, end)
   deleteOffsets(textarea, start, end)
+  return { text: yanked, linewise: true }
+}
+
+export function yankLine(textarea: TextareaRenderable): VimRegister {
+  const text = textarea.plainText
+  const start = lineStart(text, textarea.cursorOffset)
+  const end = lineEnd(text, textarea.cursorOffset)
+  return { text: text.slice(start, end), linewise: true }
+}
+
+export function yankWord(textarea: TextareaRenderable): VimRegister {
+  const text = textarea.plainText
+  const start = textarea.cursorOffset
+  const end = nextWordStart(text, start, false)
+  if (end <= start) return null
+  return { text: text.slice(start, end), linewise: false }
+}
+
+export function pasteAfter(textarea: TextareaRenderable, reg: VimRegister) {
+  if (!reg) return
+  if (reg.linewise) {
+    const text = textarea.plainText
+    const end = lineEnd(text, textarea.cursorOffset)
+    textarea.cursorOffset = end
+    textarea.insertText("\n" + reg.text)
+    textarea.cursorOffset = end + 1
+    return
+  }
+  textarea.cursorOffset = Math.min(textarea.cursorOffset + 1, textarea.plainText.length)
+  textarea.insertText(reg.text)
+  textarea.cursorOffset = textarea.cursorOffset - 1
+}
+
+export function pasteBefore(textarea: TextareaRenderable, reg: VimRegister) {
+  if (!reg) return
+  if (reg.linewise) {
+    const text = textarea.plainText
+    const start = lineStart(text, textarea.cursorOffset)
+    textarea.cursorOffset = start
+    textarea.insertText(reg.text + "\n")
+    textarea.cursorOffset = start
+    return
+  }
+  textarea.insertText(reg.text)
+  textarea.cursorOffset = textarea.cursorOffset - 1
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -346,8 +346,9 @@ export function pasteBefore(textarea: TextareaRenderable, reg: VimRegister) {
 
 export function syncSelection(textarea: TextareaRenderable, anchor: number, linewise = false) {
   const text = textarea.plainText
-  let lo = Math.min(anchor, textarea.cursorOffset)
-  let hi = Math.max(anchor + 1, textarea.cursorOffset + 1)
+  const cursor = textarea.cursorOffset
+  let lo = Math.min(anchor, cursor)
+  let hi = Math.max(anchor + 1, cursor + 1)
   if (linewise) {
     lo = lineStart(text, lo)
     hi = lineEnd(text, hi - 1)
@@ -360,17 +361,61 @@ export function clearSelection(textarea: TextareaRenderable) {
   textarea.editorView.resetSelection()
 }
 
-export function deleteSelection(textarea: TextareaRenderable, linewise = false): VimRegister {
+function selectionRange(textarea: TextareaRenderable, anchor?: number, linewise = false) {
   const sel = textarea.editorView.getSelection()
-  if (!sel) return null
-  const text = textarea.plainText.slice(sel.start, sel.end)
-  textarea.editorView.deleteSelectedText()
-  textarea.cursorOffset = sel.start
-  return { text, linewise }
+  if (sel) return sel
+  if (anchor === undefined) return null
+  let start = Math.min(anchor, textarea.cursorOffset)
+  let end = Math.max(anchor + 1, textarea.cursorOffset + 1)
+  if (linewise) {
+    const text = textarea.plainText
+    start = lineStart(text, start)
+    end = lineEnd(text, end - 1)
+    if (end < text.length) end++
+  }
+  return { start, end }
 }
 
-export function yankSelection(textarea: TextareaRenderable, linewise = false): VimRegister {
-  const sel = textarea.editorView.getSelection()
+export function deleteSelection(textarea: TextareaRenderable, linewise = false, anchor?: number): VimRegister {
+  const sel = selectionRange(textarea, anchor, linewise)
+  if (!sel) return null
+  const text = textarea.plainText
+  const yanked = text.slice(sel.start, sel.end)
+
+  let start = sel.start
+  let end = sel.end
+  // ensure delete complete lines to avoid leaving empty lines
+  if (linewise) {
+    const hasTrailingNl = end < text.length && text[end - 1] === "\n"
+    const hasLeadingNl = start > 0 && text[start - 1] === "\n"
+    if (!hasTrailingNl && end < text.length && text[end] === "\n") {
+      end++
+    } else if (!hasTrailingNl && hasLeadingNl) {
+      start--
+    }
+  }
+
+  // clear editor selection before manual delete
+  if (textarea.editorView.getSelection()) {
+    textarea.editorView.resetSelection()
+  }
+  deleteOffsets(textarea, start, end)
+
+  const after = textarea.plainText
+  if (linewise) {
+    if (start >= after.length && start > 0) {
+      textarea.cursorOffset = lineStart(after, after.length - 1)
+    } else {
+      textarea.cursorOffset = lineStart(after, Math.min(start, Math.max(after.length - 1, 0)))
+    }
+  } else {
+    textarea.cursorOffset = Math.min(start, Math.max(after.length - 1, 0))
+  }
+  return { text: yanked, linewise }
+}
+
+export function yankSelection(textarea: TextareaRenderable, linewise = false, anchor?: number): VimRegister {
+  const sel = selectionRange(textarea, anchor, linewise)
   if (!sel) return null
   return { text: textarea.plainText.slice(sel.start, sel.end), linewise }
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -343,3 +343,28 @@ export function pasteBefore(textarea: TextareaRenderable, reg: VimRegister) {
   textarea.insertText(reg.text)
   textarea.cursorOffset = textarea.cursorOffset - 1
 }
+
+export function syncSelection(textarea: TextareaRenderable, anchor: number) {
+  const lo = Math.min(anchor, textarea.cursorOffset)
+  const hi = Math.max(anchor + 1, textarea.cursorOffset + 1)
+  textarea.editorView.setSelection(lo, hi)
+}
+
+export function clearSelection(textarea: TextareaRenderable) {
+  textarea.editorView.resetSelection()
+}
+
+export function deleteSelection(textarea: TextareaRenderable): VimRegister {
+  const sel = textarea.editorView.getSelection()
+  if (!sel) return null
+  const text = textarea.plainText.slice(sel.start, sel.end)
+  textarea.editorView.deleteSelectedText()
+  textarea.cursorOffset = sel.start
+  return { text, linewise: false }
+}
+
+export function yankSelection(textarea: TextareaRenderable): VimRegister {
+  const sel = textarea.editorView.getSelection()
+  if (!sel) return null
+  return { text: textarea.plainText.slice(sel.start, sel.end), linewise: false }
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 
-export type VimMode = "normal" | "insert"
+export type VimMode = "normal" | "insert" | "visual"
 export type VimPending = "" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y"
 export type VimFind = { char: string; forward: boolean; till: boolean } | null
 export type VimRegister = { text: string; linewise: boolean } | null
@@ -10,6 +10,7 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
   const [pending, setPending] = createSignal<VimPending>("")
   const [lastFind, setLastFind] = createSignal<VimFind>(null)
   const [register, setRegister] = createSignal<VimRegister>(null)
+  const [anchor, setAnchor] = createSignal<number | null>(null)
 
   function clearPending() {
     if (pending()) setPending("")
@@ -17,6 +18,7 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
 
   function changeMode(next: VimMode) {
     clearPending()
+    if (next !== "visual") setAnchor(null)
     setMode(next)
   }
 
@@ -40,10 +42,14 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
     setLastFind,
     register,
     setRegister,
+    anchor,
+    setAnchor,
     reset() {
       clearPending()
+      setAnchor(null)
       setMode("insert")
     },
     isInsert: createMemo(() => mode() === "insert"),
+    isVisual: createMemo(() => mode() === "visual"),
   }
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,13 +1,15 @@
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 
 export type VimMode = "normal" | "insert"
-export type VimPending = "" | "c" | "d" | "g" | "f" | "F" | "t" | "T"
+export type VimPending = "" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y"
 export type VimFind = { char: string; forward: boolean; till: boolean } | null
+export type VimRegister = { text: string; linewise: boolean } | null
 
 export function createVimState(input: { enabled: Accessor<boolean>; initial?: Accessor<VimMode | undefined> }) {
   const [mode, setMode] = createSignal<VimMode>(input.initial?.() ?? "insert")
   const [pending, setPending] = createSignal<VimPending>("")
   const [lastFind, setLastFind] = createSignal<VimFind>(null)
+  const [register, setRegister] = createSignal<VimRegister>(null)
 
   function clearPending() {
     if (pending()) setPending("")
@@ -36,6 +38,8 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
     clearPending,
     lastFind,
     setLastFind,
+    register,
+    setRegister,
     reset() {
       clearPending()
       setMode("insert")

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 
-export type VimMode = "normal" | "insert" | "visual"
+export type VimMode = "normal" | "insert" | "visual" | "visual-line"
 export type VimPending = "" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y"
 export type VimFind = { char: string; forward: boolean; till: boolean } | null
 export type VimRegister = { text: string; linewise: boolean } | null
@@ -18,7 +18,7 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
 
   function changeMode(next: VimMode) {
     clearPending()
-    if (next !== "visual") setAnchor(null)
+    if (next !== "visual" && next !== "visual-line") setAnchor(null)
     setMode(next)
   }
 
@@ -50,6 +50,7 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
       setMode("insert")
     },
     isInsert: createMemo(() => mode() === "insert"),
-    isVisual: createMemo(() => mode() === "visual"),
+    isVisual: createMemo(() => mode() === "visual" || mode() === "visual-line"),
+    isVisualLine: createMemo(() => mode() === "visual-line"),
   }
 }

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -88,8 +88,9 @@ function createHandler(
   const textarea = createTextarea(text)
   const [enabled] = createSignal(options?.enabled ?? true)
   const [mode, setMode] = createSignal<"normal" | "insert">(options?.mode ?? "normal")
-  const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "f" | "F" | "t" | "T">("")
+  const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y">("")
   const [lastFind, setLastFind] = createSignal<{ char: string; forward: boolean; till: boolean } | null>(null)
+  const [register, setRegister] = createSignal<{ text: string; linewise: boolean } | null>(null)
   const scrollCalls: VimScroll[] = []
   const jumpCalls: VimJump[] = []
 
@@ -102,10 +103,7 @@ function createHandler(
     setMode(next)
   }
 
-  const state: Pick<
-    ReturnType<typeof createVimState>,
-    "mode" | "setMode" | "reset" | "isInsert" | "pending" | "setPending" | "clearPending" | "lastFind" | "setLastFind"
-  > = {
+  const state: ReturnType<typeof createVimState> = {
     mode,
     setMode: changeMode,
     pending,
@@ -113,12 +111,14 @@ function createHandler(
     clearPending,
     lastFind,
     setLastFind,
+    register,
+    setRegister,
     reset() {
       clearPending()
       setMode("insert")
     },
     isInsert: () => mode() === "insert",
-  }
+  } as ReturnType<typeof createVimState>
   const handler = createVimHandler({
     enabled,
     state,
@@ -1007,6 +1007,179 @@ describe("vim motion handler", () => {
 
     ctx.handler.handleKey(createEvent(",").event)
     expect(ctx.textarea.cursorOffset).toBe(3)
+  })
+
+  test("yy yanks current line into register", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "two", linewise: true })
+    expect(ctx.textarea.cursorOffset).toBe(5)
+    expect(ctx.textarea.plainText).toBe("one\ntwo\nthree")
+  })
+
+  test("yw yanks word into register", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("w").event)
+    expect(ctx.state.register()).toEqual({ text: "hello ", linewise: false })
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.textarea.plainText).toBe("hello world")
+  })
+
+  test("p pastes linewise below current line", () => {
+    const ctx = createHandler("one\ntwo")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("y").event)
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("one\none\ntwo")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("P pastes linewise above current line", () => {
+    const ctx = createHandler("one\ntwo")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("y").event)
+
+    ctx.handler.handleKey(createEvent("P").event)
+    expect(ctx.textarea.plainText).toBe("one\ntwo\ntwo")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("p pastes characterwise after cursor", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("w").event)
+
+    ctx.textarea.cursorOffset = 6
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("hello whello orld")
+    expect(ctx.textarea.cursorOffset).toBe(12)
+  })
+
+  test("P pastes characterwise before cursor", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("w").event)
+
+    ctx.textarea.cursorOffset = 6
+    ctx.handler.handleKey(createEvent("P").event)
+    expect(ctx.textarea.plainText).toBe("hello hello world")
+    expect(ctx.textarea.cursorOffset).toBe(11)
+  })
+
+  test("p with empty register is no-op", () => {
+    const ctx = createHandler("hello")
+    ctx.textarea.cursorOffset = 2
+
+    const p = createEvent("p")
+    expect(ctx.handler.handleKey(p.event)).toBe(true)
+    expect(p.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("hello")
+    expect(ctx.textarea.cursorOffset).toBe(2)
+  })
+
+  test("yy then p multiple times", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("y").event)
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("abc\nabc")
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("abc\nabc\nabc")
+  })
+
+  test("dd populates register", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.state.register()).toEqual({ text: "two", linewise: true })
+  })
+
+  test("dw populates register", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("w").event)
+    expect(ctx.state.register()).toEqual({ text: "hello ", linewise: false })
+  })
+
+  test("x populates register", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("x").event)
+    expect(ctx.state.register()).toEqual({ text: "b", linewise: false })
+  })
+
+  test("pending y clears on escape", () => {
+    const ctx = createHandler("hello")
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    ctx.handler.handleKey(createEvent("escape").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toBe(null)
+  })
+
+  test("pending y clears on invalid key", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 2
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    ctx.handler.handleKey(createEvent("h").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+  })
+
+  test("pending y clears on modifier key", () => {
+    const ctx = createHandler("abc")
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.state.pending()).toBe("y")
+
+    const mod = createEvent("j", { ctrl: true })
+    expect(ctx.handler.handleKey(mod.event)).toBe(false)
+    expect(mod.prevented()).toBe(false)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("dd then p pastes deleted line below", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe("one\nthree")
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("one\nthree\ntwo")
   })
 
   test("pending d clears on escape", () => {

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -1478,6 +1478,19 @@ describe("vim motion handler", () => {
     expect((ctx.textarea as any).editorView.getSelection()).toBe(null)
   })
 
+  test("i does not enter insert in visual mode", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 2
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.mode()).toBe("visual")
+
+    const i = createEvent("i")
+    expect(ctx.handler.handleKey(i.event)).toBe(true)
+    expect(i.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("visual")
+  })
+
   test("v twice toggles back to normal", () => {
     const ctx = createHandler("hello")
     ctx.textarea.cursorOffset = 1
@@ -1504,6 +1517,19 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.plainText).toBe(" world")
     expect(ctx.state.mode()).toBe("normal")
     expect(ctx.state.register()).toEqual({ text: "hello", linewise: false })
+  })
+
+  test("visual d falls back to anchor when editor selection is cleared", () => {
+    const ctx = createHandler("hello")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ;(ctx.textarea as any).editorView.resetSelection()
+
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe("hllo")
+    expect(ctx.state.register()).toEqual({ text: "e", linewise: false })
+    expect(ctx.state.mode()).toBe("normal")
   })
 
   test("visual y yanks selection without deleting", () => {
@@ -1644,6 +1670,19 @@ describe("vim motion handler", () => {
     expect(ctx.state.register()?.linewise).toBe(true)
   })
 
+  test("V then d falls back to anchor when editor selection is cleared", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("V").event)
+    ;(ctx.textarea as any).editorView.resetSelection()
+
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe("one\nthree")
+    expect(ctx.state.register()).toEqual({ text: "two\n", linewise: true })
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
   test("V then y yanks full lines with linewise register", () => {
     const ctx = createHandler("one\ntwo\nthree")
     ctx.textarea.cursorOffset = 5
@@ -1653,6 +1692,31 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.plainText).toBe("one\ntwo\nthree")
     expect(ctx.state.mode()).toBe("normal")
     expect(ctx.state.register()).toEqual({ text: "two\n", linewise: true })
+  })
+
+  test("V select lines 2-4 then d places cursor at line 1 start", () => {
+    const ctx = createHandler("line 1\nline 2\nline 3\nline 4")
+    ctx.textarea.cursorOffset = 7
+
+    ctx.handler.handleKey(createEvent("V").event)
+    ctx.handler.handleKey(createEvent("j").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe("line 1")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("V delete middle line places cursor at next line start", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("V").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe("one\nthree")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+    expect(ctx.state.mode()).toBe("normal")
   })
 
   test("V then escape exits", () => {

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -37,6 +37,7 @@ function offsetToRowCol(text: string, offset: number) {
 }
 
 function createTextarea(text: string) {
+  let sel: { start: number; end: number } | null = null
   const textarea = {
     plainText: text,
     cursorOffset: 0,
@@ -54,6 +55,30 @@ function createTextarea(text: string) {
       const end = rowColToOffset(textarea.plainText, endRow, endCol)
       textarea.plainText = textarea.plainText.slice(0, start) + textarea.plainText.slice(end)
       textarea.cursorOffset = start
+    },
+    editorView: {
+      setSelection(start: number, end: number) {
+        sel = { start, end }
+      },
+      resetSelection() {
+        sel = null
+      },
+      getSelection() {
+        return sel
+      },
+      hasSelection() {
+        return sel !== null
+      },
+      getSelectedText() {
+        if (!sel) return ""
+        return textarea.plainText.slice(sel.start, sel.end)
+      },
+      deleteSelectedText() {
+        if (!sel) return
+        textarea.plainText = textarea.plainText.slice(0, sel.start) + textarea.plainText.slice(sel.end)
+        textarea.cursorOffset = sel.start
+        sel = null
+      },
     },
   }
   return textarea as unknown as TextareaRenderable
@@ -80,17 +105,18 @@ function createHandler(
   text: string,
   options?: {
     enabled?: boolean
-    mode?: "normal" | "insert"
+    mode?: "normal" | "insert" | "visual"
     submit?: () => void
     autocomplete?: () => false | "@" | "/"
   },
 ) {
   const textarea = createTextarea(text)
   const [enabled] = createSignal(options?.enabled ?? true)
-  const [mode, setMode] = createSignal<"normal" | "insert">(options?.mode ?? "normal")
+  const [mode, setMode] = createSignal<"normal" | "insert" | "visual">(options?.mode ?? "normal")
   const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y">("")
   const [lastFind, setLastFind] = createSignal<{ char: string; forward: boolean; till: boolean } | null>(null)
   const [register, setRegister] = createSignal<{ text: string; linewise: boolean } | null>(null)
+  const [anchor, setAnchor] = createSignal<number | null>(null)
   const scrollCalls: VimScroll[] = []
   const jumpCalls: VimJump[] = []
 
@@ -98,8 +124,9 @@ function createHandler(
     setPending("")
   }
 
-  function changeMode(next: "normal" | "insert") {
+  function changeMode(next: "normal" | "insert" | "visual") {
     clearPending()
+    if (next !== "visual") setAnchor(null)
     setMode(next)
   }
 
@@ -113,11 +140,15 @@ function createHandler(
     setLastFind,
     register,
     setRegister,
+    anchor,
+    setAnchor,
     reset() {
       clearPending()
+      setAnchor(null)
       setMode("insert")
     },
     isInsert: () => mode() === "insert",
+    isVisual: () => mode() === "visual",
   } as ReturnType<typeof createVimState>
   const handler = createVimHandler({
     enabled,
@@ -1395,6 +1426,170 @@ describe("vim motion handler", () => {
     expect(ctx.state.pending()).toBe("")
 
     expect(ctx.jumpCalls).toEqual(["bottom", "bottom"])
+  })
+
+  test("v enters visual mode and sets selection", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 2
+
+    const v = createEvent("v")
+    expect(ctx.handler.handleKey(v.event)).toBe(true)
+    expect(v.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("visual")
+    expect(ctx.state.anchor()).toBe(2)
+  })
+
+  test("v then motion extends selection", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.mode()).toBe("visual")
+
+    ctx.handler.handleKey(createEvent("l").event)
+    expect(ctx.textarea.cursorOffset).toBe(1)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 2 })
+
+    ctx.handler.handleKey(createEvent("l").event)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 3 })
+  })
+
+  test("v then w extends selection by word", () => {
+    const ctx = createHandler("hello world test")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("w").event)
+    expect(ctx.textarea.cursorOffset).toBe(6)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 7 })
+  })
+
+  test("v then escape exits visual mode", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 2
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.mode()).toBe("visual")
+
+    ctx.handler.handleKey(createEvent("escape").event)
+    expect(ctx.state.mode()).toBe("normal")
+    expect((ctx.textarea as any).editorView.getSelection()).toBe(null)
+  })
+
+  test("v twice toggles back to normal", () => {
+    const ctx = createHandler("hello")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.mode()).toBe("visual")
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.mode()).toBe("normal")
+    expect((ctx.textarea as any).editorView.getSelection()).toBe(null)
+  })
+
+  test("visual d deletes selection and populates register", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe(" world")
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.register()).toEqual({ text: "hello", linewise: false })
+  })
+
+  test("visual y yanks selection without deleting", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.textarea.plainText).toBe("hello world")
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.register()).toEqual({ text: "hello", linewise: false })
+  })
+
+  test("visual c deletes selection and enters insert", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+
+    ctx.handler.handleKey(createEvent("c").event)
+    expect(ctx.textarea.plainText).toBe(" world")
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.register()).toEqual({ text: "hello", linewise: false })
+  })
+
+  test("visual x is same as d", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+
+    ctx.handler.handleKey(createEvent("x").event)
+    expect(ctx.textarea.plainText).toBe("lo world")
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.register()).toEqual({ text: "hel", linewise: false })
+  })
+
+  test("visual p replaces selection with register", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 6
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("w").event)
+    expect(ctx.state.register()).toEqual({ text: "world", linewise: false })
+
+    ctx.textarea.cursorOffset = 0
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+
+    ctx.handler.handleKey(createEvent("p").event)
+    expect(ctx.textarea.plainText).toBe("world world")
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("visual mode with backward motion", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("h").event)
+    ctx.handler.handleKey(createEvent("h").event)
+    expect(ctx.textarea.cursorOffset).toBe(3)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 3, end: 6 })
+  })
+
+  test("visual mode $ selects to end of line", () => {
+    const ctx = createHandler("hello world")
+    ctx.textarea.cursorOffset = 6
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("$").event)
+    expect(ctx.textarea.cursorOffset).toBe(10)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 6, end: 11 })
   })
 })
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -105,14 +105,14 @@ function createHandler(
   text: string,
   options?: {
     enabled?: boolean
-    mode?: "normal" | "insert" | "visual"
+    mode?: "normal" | "insert" | "visual" | "visual-line"
     submit?: () => void
     autocomplete?: () => false | "@" | "/"
   },
 ) {
   const textarea = createTextarea(text)
   const [enabled] = createSignal(options?.enabled ?? true)
-  const [mode, setMode] = createSignal<"normal" | "insert" | "visual">(options?.mode ?? "normal")
+  const [mode, setMode] = createSignal<"normal" | "insert" | "visual" | "visual-line">(options?.mode ?? "normal")
   const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "f" | "F" | "t" | "T" | "y">("")
   const [lastFind, setLastFind] = createSignal<{ char: string; forward: boolean; till: boolean } | null>(null)
   const [register, setRegister] = createSignal<{ text: string; linewise: boolean } | null>(null)
@@ -124,9 +124,9 @@ function createHandler(
     setPending("")
   }
 
-  function changeMode(next: "normal" | "insert" | "visual") {
+  function changeMode(next: "normal" | "insert" | "visual" | "visual-line") {
     clearPending()
-    if (next !== "visual") setAnchor(null)
+    if (next !== "visual" && next !== "visual-line") setAnchor(null)
     setMode(next)
   }
 
@@ -148,7 +148,8 @@ function createHandler(
       setMode("insert")
     },
     isInsert: () => mode() === "insert",
-    isVisual: () => mode() === "visual",
+    isVisual: () => mode() === "visual" || mode() === "visual-line",
+    isVisualLine: () => mode() === "visual-line",
   } as ReturnType<typeof createVimState>
   const handler = createVimHandler({
     enabled,
@@ -1590,6 +1591,111 @@ describe("vim motion handler", () => {
     ctx.handler.handleKey(createEvent("$").event)
     expect(ctx.textarea.cursorOffset).toBe(10)
     expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 6, end: 11 })
+  })
+
+  test("V enters visual-line mode", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    const v = createEvent("V")
+    expect(ctx.handler.handleKey(v.event)).toBe(true)
+    expect(v.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("visual-line")
+    expect(ctx.state.anchor()).toBe(5)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 4, end: 8 })
+  })
+
+  test("V selects full current line on single line", () => {
+    const ctx = createHandler("hello")
+    ctx.textarea.cursorOffset = 2
+
+    ctx.handler.handleKey(createEvent("V").event)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 5 })
+  })
+
+  test("V then j extends by full line", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("V").event)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 4 })
+
+    ctx.handler.handleKey(createEvent("j").event)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 8 })
+  })
+
+  test("V then k extends upward by full line", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("V").event)
+    ctx.handler.handleKey(createEvent("k").event)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 8 })
+  })
+
+  test("V then d deletes full lines with linewise register", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("V").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.textarea.plainText).toBe("one\nthree")
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.register()?.linewise).toBe(true)
+  })
+
+  test("V then y yanks full lines with linewise register", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("V").event)
+    ctx.handler.handleKey(createEvent("y").event)
+    expect(ctx.textarea.plainText).toBe("one\ntwo\nthree")
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.register()).toEqual({ text: "two\n", linewise: true })
+  })
+
+  test("V then escape exits", () => {
+    const ctx = createHandler("hello")
+    ctx.handler.handleKey(createEvent("V").event)
+    expect(ctx.state.mode()).toBe("visual-line")
+
+    ctx.handler.handleKey(createEvent("escape").event)
+    expect(ctx.state.mode()).toBe("normal")
+    expect((ctx.textarea as any).editorView.getSelection()).toBe(null)
+  })
+
+  test("V twice toggles off", () => {
+    const ctx = createHandler("hello")
+    ctx.handler.handleKey(createEvent("V").event)
+    expect(ctx.state.mode()).toBe("visual-line")
+
+    ctx.handler.handleKey(createEvent("V").event)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("v in visual-line switches to characterwise", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("V").event)
+    expect(ctx.state.mode()).toBe("visual-line")
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.mode()).toBe("visual")
+    expect(ctx.state.anchor()).toBe(5)
+  })
+
+  test("V in characterwise visual switches to visual-line", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.mode()).toBe("visual")
+
+    ctx.handler.handleKey(createEvent("V").event)
+    expect(ctx.state.mode()).toBe("visual-line")
+    expect(ctx.state.anchor()).toBe(5)
   })
 })
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -38,6 +38,7 @@ function offsetToRowCol(text: string, offset: number) {
 
 function createTextarea(text: string) {
   let sel: { start: number; end: number } | null = null
+  let anchor: number | null = null
   const textarea = {
     plainText: text,
     cursorOffset: 0,
@@ -56,12 +57,26 @@ function createTextarea(text: string) {
       textarea.plainText = textarea.plainText.slice(0, start) + textarea.plainText.slice(end)
       textarea.cursorOffset = start
     },
+    updateSelectionForMovement(shift: boolean, before: boolean) {
+      if (!shift) {
+        anchor = null
+        sel = null
+        return
+      }
+      if (before) {
+        anchor = textarea.cursorOffset
+        return
+      }
+      if (anchor === null) return
+      sel = { start: Math.min(anchor, textarea.cursorOffset), end: Math.max(anchor, textarea.cursorOffset) }
+    },
     editorView: {
       setSelection(start: number, end: number) {
         sel = { start, end }
       },
       resetSelection() {
         sel = null
+        anchor = null
       },
       getSelection() {
         return sel

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -410,7 +410,7 @@ Enable it from the command palette or in your config.
 
 **Movement:** `h`, `j`, `k`, `l`, `0`, `^`/`_`, `$`; `w`, `b`, `e`, `W`, `B`, `E`; `f`, `F`, `t`, `T`, `;`, `,`
 
-**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`
+**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`; `yy`, `yw`, `p`, `P`
 
 **Navigation:** `gg`, `G`
 

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -410,7 +410,7 @@ Enable it from the command palette or in your config.
 
 **Movement:** `h`, `j`, `k`, `l`, `0`, `^`/`_`, `$`; `w`, `b`, `e`, `W`, `B`, `E`; `f`, `F`, `t`, `T`, `;`, `,`
 
-**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`; `yy`, `yw`, `p`, `P`; `v` (visual mode)
+**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`; `yy`, `yw`, `p`, `P`; `v` (visual), `V` (visual line)
 
 **Navigation:** `gg`, `G`
 

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -410,7 +410,7 @@ Enable it from the command palette or in your config.
 
 **Movement:** `h`, `j`, `k`, `l`, `0`, `^`/`_`, `$`; `w`, `b`, `e`, `W`, `B`, `E`; `f`, `F`, `t`, `T`, `;`, `,`
 
-**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`; `yy`, `yw`, `p`, `P`
+**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `J`, `cc`, `cw`; `dd`, `dw`; `yy`, `yw`, `p`, `P`; `v` (visual mode)
 
 **Navigation:** `gg`, `G`
 


### PR DESCRIPTION
Part of #5 
Add visual (`v`) and visual-line (`V`) modes with selection operators 