### PR TITLE
feat(tui): add minimal UI toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ ocv update
 `f` `F` `t` `T` `;` `,`
 `Ctrl+e` `Ctrl+y` `Ctrl+d` `Ctrl+u` `Ctrl+f` `Ctrl+b`
 
+## Minimal UI Toggle
+
+- Hide extra UI hints
+- Settings -> Enable minimal UI
+
 ## Feedback
 
 Have a suggestion? [Open an issue](https://github.com/leohenon/opencode/issues).

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -668,6 +668,15 @@ function App() {
       },
     },
     {
+      title: kv.get("ui_minimal", false) ? "Disable minimal UI" : "Enable minimal UI",
+      value: "ui.minimal.toggle",
+      category: "Settings",
+      onSelect: (dialog) => {
+        kv.set("ui_minimal", !kv.get("ui_minimal", false))
+        dialog.clear()
+      },
+    },
+    {
       title: kv.get("animations_enabled", true) ? "Disable animations" : "Enable animations",
       value: "app.toggle.animations",
       category: "System",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -86,6 +86,7 @@ export function Prompt(props: PromptProps) {
   const { theme, syntax } = useTheme()
   const kv = useKV()
   const vimEnabled = useVimEnabled()
+  const mini = createMemo(() => kv.get("ui_minimal", false))
 
   function promptModelWarning() {
     toast.show({
@@ -866,6 +867,8 @@ export function Prompt(props: PromptProps) {
   })
 
   const placeholderText = createMemo(() => {
+    if (props.showPlaceholder === false) return undefined
+    if (mini()) return undefined
     if (props.sessionID) return undefined
     if (store.mode === "shell") {
       const example = SHELL_PLACEHOLDERS[store.placeholder % SHELL_PLACEHOLDERS.length]
@@ -1260,7 +1263,7 @@ export function Prompt(props: PromptProps) {
               </text>
             </box>
           </Show>
-          <Show when={status().type !== "retry"}>
+          <Show when={status().type !== "retry" && !mini()}>
             <box gap={2} flexDirection="row">
               <Switch>
                 <Match when={store.mode === "normal"}>

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,7 +1,6 @@
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import { createEffect, createMemo, Match, on, onMount, Show, Switch } from "solid-js"
 import { useTheme } from "@tui/context/theme"
-import { useKeybind } from "@tui/context/keybind"
 import { Logo } from "../component/logo"
 import { Tips } from "../component/tips"
 import { Locale } from "@/util/locale"
@@ -36,8 +35,10 @@ export function Home() {
   })
 
   const isFirstTimeUser = createMemo(() => sync.data.session.length === 0)
+  const mini = createMemo(() => kv.get("ui_minimal", false))
   const tipsHidden = createMemo(() => kv.get("tips_hidden", false))
   const showTips = createMemo(() => {
+    if (mini()) return false
     // Don't show tips for first-time users
     if (isFirstTimeUser()) return false
     return !tipsHidden()
@@ -103,8 +104,6 @@ export function Home() {
   )
   const directory = useDirectory()
 
-  const keybind = useKeybind()
-
   return (
     <>
       <box flexGrow={1} alignItems="center" paddingLeft={2} paddingRight={2}>
@@ -152,7 +151,9 @@ export function Home() {
         </box>
         <box flexGrow={1} />
         <box flexShrink={0}>
-          <text fg={theme.textMuted}>{Installation.VERSION}</text>
+          <Show when={!mini()}>
+            <text fg={theme.textMuted}>{Installation.VERSION}</text>
+          </Show>
         </box>
       </box>
     </>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -7,6 +7,7 @@ import { SplitBorder } from "@tui/component/border"
 import type { AssistantMessage, Session } from "@opencode-ai/sdk/v2"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
+import { useKV } from "../../context/kv"
 import { Flag } from "@/flag/flag"
 import { useTerminalDimensions } from "@opentui/solid"
 
@@ -81,6 +82,8 @@ export function Header() {
 
   const { theme } = useTheme()
   const keybind = useKeybind()
+  const kv = useKV()
+  const mini = createMemo(() => kv.get("ui_minimal", false))
   const command = useCommandDialog()
   const [hover, setHover] = createSignal<"parent" | "prev" | "next" | null>(null)
   const dimensions = useTerminalDimensions()
@@ -126,7 +129,10 @@ export function Header() {
                   backgroundColor={hover() === "parent" ? theme.backgroundElement : theme.backgroundPanel}
                 >
                   <text fg={theme.text}>
-                    Parent <span style={{ fg: theme.textMuted }}>{keybind.print("session_parent")}</span>
+                    Parent
+                    <Show when={!mini()}>
+                      <span style={{ fg: theme.textMuted }}> {keybind.print("session_parent")}</span>
+                    </Show>
                   </text>
                 </box>
                 <box
@@ -136,7 +142,10 @@ export function Header() {
                   backgroundColor={hover() === "prev" ? theme.backgroundElement : theme.backgroundPanel}
                 >
                   <text fg={theme.text}>
-                    Prev <span style={{ fg: theme.textMuted }}>{keybind.print("session_child_cycle_reverse")}</span>
+                    Prev
+                    <Show when={!mini()}>
+                      <span style={{ fg: theme.textMuted }}> {keybind.print("session_child_cycle_reverse")}</span>
+                    </Show>
                   </text>
                 </box>
                 <box
@@ -146,7 +155,10 @@ export function Header() {
                   backgroundColor={hover() === "next" ? theme.backgroundElement : theme.backgroundPanel}
                 >
                   <text fg={theme.text}>
-                    Next <span style={{ fg: theme.textMuted }}>{keybind.print("session_child_cycle")}</span>
+                    Next
+                    <Show when={!mini()}>
+                      <span style={{ fg: theme.textMuted }}> {keybind.print("session_child_cycle")}</span>
+                    </Show>
                   </text>
                 </box>
               </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -102,6 +102,7 @@ const context = createContext<{
   showTimestamps: () => boolean
   showDetails: () => boolean
   showGenericToolOutput: () => boolean
+  showHints: () => boolean
   diffWrapMode: () => "word" | "none"
   sync: ReturnType<typeof useSync>
   tui: ReturnType<typeof useTuiConfig>
@@ -159,6 +160,8 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const mini = createMemo(() => kv.get("ui_minimal", false))
+  const showHints = createMemo(() => !mini())
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -1040,6 +1043,7 @@ export function Session() {
         showTimestamps,
         showDetails,
         showGenericToolOutput,
+        showHints,
         diffWrapMode,
         sync,
         tui: tuiConfig,
@@ -1107,10 +1111,12 @@ export function Session() {
                               backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
                             >
                               <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
-                              <text fg={theme.textMuted}>
-                                <span style={{ fg: theme.text }}>{keybind.print("messages_redo")}</span> or /redo to
-                                restore
-                              </text>
+                              <Show when={showHints()}>
+                                <text fg={theme.textMuted}>
+                                  <span style={{ fg: theme.text }}>{keybind.print("messages_redo")}</span> or /redo to
+                                  restore
+                                </text>
+                              </Show>
                               <Show when={revert()!.diffFiles?.length}>
                                 <box marginTop={1}>
                                   <For each={revert()!.diffFiles}>
@@ -1325,6 +1331,7 @@ function UserMessage(props: {
 }
 
 function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; last: boolean }) {
+  const ctx = use()
   const local = useLocal()
   const { theme } = useTheme()
   const sync = useSync()
@@ -1361,7 +1368,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           )
         }}
       </For>
-      <Show when={props.parts.some((x) => x.type === "tool" && x.tool === "task")}>
+      <Show when={props.parts.some((x) => x.type === "tool" && x.tool === "task") && ctx.showHints()}>
         <box paddingTop={1} paddingLeft={3}>
           <text fg={theme.text}>
             {keybind.print("session_child_first")}


### PR DESCRIPTION
Closes #13 

Added a persistent Minimal UI toggle. 
It hides extra hints across home + session.  
Hide/Show tips still only controls the home tips. 