### PR TITLE
fix(vim): escape in visual mode exits to normal instead of interrupting

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -299,7 +299,8 @@ export function Prompt(props: PromptProps) {
         onSelect: (dialog) => {
           if (autocomplete.visible) return
           if (!input.focused) return
-          if (vimEnabled() && store.mode === "normal" && vimState.isInsert()) {
+          if (vimEnabled() && store.mode === "normal" && vimState.mode() !== "normal") {
+            if (vimState.isVisual()) clearSelection(input)
             vimState.setMode("normal")
             setStore("interrupt", 0)
             dialog.clear()


### PR DESCRIPTION
Escape in visual mode exits to normal instead of interrupting.