### PR TITLE
feat: add vim_enter_submit option to submit with enter in insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Hides extra UI hints and tips.
 > [!TIP]
 > Toggle via command palette (`Ctrl+p` -> `Toggle minimal ui`).
 
+## Configuration
+
+### Submit behavior
+
+By default, vim insert mode keeps `Enter` for newlines. If you want `Enter` to submit instead, add this to `tui.json`:
+
+```json
+{
+  "vim_enter_submit": true
+}
+```
+
 ## Feedback
 
 Have a suggestion? [Open an issue](https://github.com/leohenon/opencode/issues).

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,6 +32,7 @@ import { useCommandDialog } from "../dialog-command"
 import { useKeyboard, useRenderer } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
+import { useTuiConfig } from "../../context/tui-config"
 import { Clipboard } from "../../util/clipboard"
 import type { FilePart } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
@@ -116,6 +117,7 @@ export function Prompt(props: PromptProps) {
   let autocomplete: AutocompleteRef
 
   const keybind = useKeybind()
+  const cfg = useTuiConfig()
   const local = useLocal()
   const sdk = useSDK()
   const route = useRoute()
@@ -733,7 +735,7 @@ export function Prompt(props: PromptProps) {
       submit()
       return
     }
-    if (vimEnabled() && (vimState.isInsert() || vimState.isReplace())) {
+    if (vimEnabled() && (vimState.isInsert() || vimState.isReplace()) && !cfg.vim_enter_submit) {
       input.insertText("\n")
       return
     }

--- a/packages/opencode/src/config/tui-migrate.ts
+++ b/packages/opencode/src/config/tui-migrate.ts
@@ -22,6 +22,7 @@ const TuiLegacy = z
     scroll_speed: TuiOptions.shape.scroll_speed.catch(undefined),
     scroll_acceleration: TuiOptions.shape.scroll_acceleration.catch(undefined),
     diff_style: TuiOptions.shape.diff_style.catch(undefined),
+    vim_enter_submit: TuiOptions.shape.vim_enter_submit.catch(undefined),
   })
   .strip()
 
@@ -92,7 +93,8 @@ function normalizeTui(data: Record<string, unknown>) {
   if (
     parsed.scroll_speed === undefined &&
     parsed.diff_style === undefined &&
-    parsed.scroll_acceleration === undefined
+    parsed.scroll_acceleration === undefined &&
+    parsed.vim_enter_submit === undefined
   ) {
     return
   }

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -31,6 +31,7 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Maximum number of rows the prompt input expands to"),
   prompt_scrollbar: z.boolean().optional().describe("Show a scrollbar for the prompt input"),
+  vim_enter_submit: z.boolean().optional().describe("Submit prompt with Enter in vim insert and replace modes"),
 })
 
 export const TuiInfo = z

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -104,7 +104,7 @@ test("loads tui config with the same precedence order as server config paths", a
       await fs.mkdir(path.join(dir, ".opencode"), { recursive: true })
       await Bun.write(
         path.join(dir, ".opencode", "tui.json"),
-        JSON.stringify({ theme: "local", diff_style: "stacked" }, null, 2),
+        JSON.stringify({ theme: "local", diff_style: "stacked", vim_enter_submit: true }, null, 2),
       )
     },
   })
@@ -115,6 +115,7 @@ test("loads tui config with the same precedence order as server config paths", a
       const config = await TuiConfig.get()
       expect(config.theme).toBe("local")
       expect(config.diff_style).toBe("stacked")
+      expect(config.vim_enter_submit).toBe(true)
     },
   })
 })
@@ -127,7 +128,7 @@ test("migrates tui-specific keys from opencode.json when tui.json does not exist
         JSON.stringify(
           {
             theme: "migrated-theme",
-            tui: { scroll_speed: 5 },
+            tui: { scroll_speed: 5, vim_enter_submit: true },
             keybinds: { app_exit: "ctrl+q" },
           },
           null,
@@ -143,11 +144,13 @@ test("migrates tui-specific keys from opencode.json when tui.json does not exist
       const config = await TuiConfig.get()
       expect(config.theme).toBe("migrated-theme")
       expect(config.scroll_speed).toBe(5)
+      expect(config.vim_enter_submit).toBe(true)
       expect(config.keybinds?.app_exit).toBe("ctrl+q")
       const text = await Filesystem.readText(path.join(tmp.path, "tui.json"))
       expect(JSON.parse(text)).toMatchObject({
         theme: "migrated-theme",
         scroll_speed: 5,
+        vim_enter_submit: true,
       })
       const server = JSON.parse(await Filesystem.readText(path.join(tmp.path, "opencode.json")))
       expect(server.theme).toBeUndefined()
@@ -360,7 +363,7 @@ test("flattens nested tui key inside tui.json", async () => {
         path.join(dir, "tui.json"),
         JSON.stringify({
           theme: "outer",
-          tui: { scroll_speed: 3, diff_style: "stacked" },
+          tui: { scroll_speed: 3, diff_style: "stacked", vim_enter_submit: true },
         }),
       )
     },
@@ -372,6 +375,7 @@ test("flattens nested tui key inside tui.json", async () => {
       const config = await TuiConfig.get()
       expect(config.scroll_speed).toBe(3)
       expect(config.diff_style).toBe("stacked")
+      expect(config.vim_enter_submit).toBe(true)
       // top-level keys take precedence over nested tui keys
       expect(config.theme).toBe("outer")
     },


### PR DESCRIPTION
closes #36 
Add `vim_enter_submit` TUI option to submit with Enter in vim insert mode