### PR TITLE
feat(visual): add support for arrow key movement in copy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Works similarly to tmux copy mode within opencode tui.
 <img src=".github/demo-copy-mode.gif" style="border: 1px solid #555; border-radius: 4px;" />
 
 - Enter copy mode with `<leader>v`.
+- Navigate with `h` `j` `k` `l` or arrow keys (`Left` `Down` `Up` `Right`).
 - Press `v` / `V` to start character-wise or line-wise selection.
 - `y` yanks to the vim register.
 - `Enter` copies to the system clipboard.

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -713,25 +713,25 @@ export function createVimHandler(input: {
       return true
     }
 
-    if (key === "j") {
+    if (key === "j" || key === "down") {
       input.copy?.("down")
       event.preventDefault()
       return true
     }
 
-    if (key === "k") {
+    if (key === "k" || key === "up") {
       input.copy?.("up")
       event.preventDefault()
       return true
     }
 
-    if (key === "h") {
+    if (key === "h" || key === "left") {
       input.copy?.("left")
       event.preventDefault()
       return true
     }
 
-    if (key === "l") {
+    if (key === "l" || key === "right") {
       input.copy?.("right")
       event.preventDefault()
       return true

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -2359,6 +2359,37 @@ describe("copy mode", () => {
     expect(ctx.copyMoves).toEqual(["left", "down", "up", "right"])
   })
 
+  test("arrow keys route to copy movement callbacks", () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { isVisual: true } })
+
+    ctx.handler.handleKey(createEvent("left").event)
+    ctx.handler.handleKey(createEvent("down").event)
+    ctx.handler.handleKey(createEvent("up").event)
+    ctx.handler.handleKey(createEvent("right").event)
+
+    expect(ctx.copyMoves).toEqual(["left", "down", "up", "right"])
+  })
+
+  test("arrow keys route to copy movement callbacks outside visual", () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { isVisual: false } })
+
+    ctx.handler.handleKey(createEvent("left").event)
+    ctx.handler.handleKey(createEvent("down").event)
+    ctx.handler.handleKey(createEvent("up").event)
+    ctx.handler.handleKey(createEvent("right").event)
+
+    expect(ctx.copyMoves).toEqual(["left", "down", "up", "right"])
+  })
+
+  test("other printable keys do not trigger copy movement", () => {
+    const ctx = createHandler("abc", { mode: "copy" })
+
+    const evt = createEvent("x")
+    expect(ctx.handler.handleKey(evt.event)).toBe(true)
+    expect(evt.prevented()).toBe(true)
+    expect(ctx.copyMoves).toEqual([])
+  })
+
   test("gg and G route to copy jump callbacks", () => {
     const ctx = createHandler("abc", { mode: "copy" })
 


### PR DESCRIPTION
- Adds support for arrow keys when in copy mode (both visual and non visual mode)
