### PR TITLE
fix: don't swallow p in insert when vim_system_clipboard_register is set

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -419,8 +419,9 @@ export function Prompt(props: PromptProps) {
   }
 
   function shouldSyncVimRegister(event: { name?: string; ctrl?: boolean; meta?: boolean; super?: boolean }) {
-    if (!useSystemClipboardRegister()) return false
+    if (!useSystemClipboardRegister() || !vimEnabled()) return false
     if (event.ctrl || event.meta || event.super) return false
+    if (vimState.isInsert() || vimState.isReplace() || vimState.isCopy()) return false
     return event.name?.toLowerCase() === "p"
   }
 


### PR DESCRIPTION
Fixes #63