### PR TITLE
fix: clamp cursor on insert escape

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -6,6 +6,7 @@ import { vimJump, type VimJump } from "./vim-motion-jump"
 import {
   appendAfterCursor,
   appendLineEnd,
+  clampCursorToLine,
   clearSelection,
   deleteLine,
   deleteLineEnd,
@@ -1110,6 +1111,7 @@ export function createVimHandler(input: {
 
       if (input.state.isInsert()) {
         if (event.name !== "escape") return false
+        clampCursorToLine(input.textarea())
         input.state.setMode("normal")
         input.state.commitEdit(snapshot())
         event.preventDefault()

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -75,6 +75,12 @@ export function moveLineEnd(textarea: TextareaRenderable) {
   textarea.cursorOffset = lineLast(text, textarea.cursorOffset)
 }
 
+export function clampCursorToLine(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const last = lineLast(text, textarea.cursorOffset)
+  if (textarea.cursorOffset > last) textarea.cursorOffset = last
+}
+
 export function moveRight(textarea: TextareaRenderable) {
   const text = textarea.plainText
   const last = lineLast(text, textarea.cursorOffset)

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -669,6 +669,38 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.cursorOffset).toBe(3)
   })
 
+  test("escape from insert clamps cursor off newline", () => {
+    const ctx = createHandler("ab\ncd")
+    ctx.textarea.cursorOffset = 0
+
+    expect(ctx.handler.handleKey(createEvent("x").event)).toBe(true)
+    expect(ctx.textarea.plainText).toBe("b\ncd")
+    expect(ctx.state.register()).toEqual({ text: "a", linewise: false })
+
+    expect(ctx.handler.handleKey(createEvent("A").event)).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+
+    expect(ctx.handler.handleKey(createEvent("escape").event)).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+
+    expect(ctx.handler.handleKey(createEvent("p").event)).toBe(true)
+    expect(ctx.textarea.plainText).toBe("ba\ncd")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+  })
+
+  test("escape from insert leaves cursor inside line content alone", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 1
+    expect(ctx.handler.handleKey(createEvent("i").event)).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+
+    expect(ctx.handler.handleKey(createEvent("escape").event)).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+  })
+
   test("o opens line below and enters insert", () => {
     const ctx = createHandler("abc\ndef")
     ctx.textarea.cursorOffset = 1


### PR DESCRIPTION
* found this while working on a new motion
* avoid leaving cursor on newline after exiting insert
* matches vim behavior so paste lands on the right line

repo steps before this fix:

1. fill input box with `abc/nde` (`\n` being a line break)
1. cursor on position `0,0` ("a")
1. do `x` to remove it
1. do `A` to go to insert mode at end of line
1. do `esc` to go back to normal mode
1. do `p` to paste the "a"
1. it will be pasted on second line, instead of end of first line