### PR TITLE
fix: use copy row offsets for word motions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/copy-mode.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/copy-mode.ts
@@ -369,12 +369,17 @@ export function createCopyMode(input: {
     setState((prev) => ({ ...prev, col: c, stick: c - min }))
   }
 
+  function wordRows(list: CopyRow[], cache: Map<string, any>) {
+    return list.map((row) => ({ col: copyMin(row, cache) }))
+  }
+
   function wordNext(big: boolean) {
     const s = state()
     if (!s.active) return false
     const list = rows()
     if (!list.length) return false
-    const next = copyWordNext(list, (idx) => rowText(list[idx]!), s.idx, s.col, big)
+    const cache = new Map(input.scroll().getChildren().map((c) => [c.id, c]))
+    const next = copyWordNext(wordRows(list, cache), (idx) => rowText(list[idx]!, cache), s.idx, s.col, big)
     if (next.idx === s.idx && next.col === s.col) return false
     if (next.idx !== s.idx) sync(next.idx)
     setCol(next.col)
@@ -386,7 +391,8 @@ export function createCopyMode(input: {
     if (!s.active) return false
     const list = rows()
     if (!list.length) return false
-    const prev = copyWordPrev(list, (idx) => rowText(list[idx]!), s.idx, s.col, big)
+    const cache = new Map(input.scroll().getChildren().map((c) => [c.id, c]))
+    const prev = copyWordPrev(wordRows(list, cache), (idx) => rowText(list[idx]!, cache), s.idx, s.col, big)
     if (prev.idx === s.idx && prev.col === s.col) return false
     if (prev.idx !== s.idx) sync(prev.idx)
     setCol(prev.col)
@@ -398,7 +404,8 @@ export function createCopyMode(input: {
     if (!s.active) return false
     const list = rows()
     if (!list.length) return false
-    const next = copyWordEnd(list, (idx) => rowText(list[idx]!), s.idx, s.col, big)
+    const cache = new Map(input.scroll().getChildren().map((c) => [c.id, c]))
+    const next = copyWordEnd(wordRows(list, cache), (idx) => rowText(list[idx]!, cache), s.idx, s.col, big)
     if (next.idx === s.idx && next.col === s.col) return false
     if (next.idx !== s.idx) sync(next.idx)
     setCol(next.col)

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -4250,6 +4250,47 @@ describe("vim scroll mapping", () => {
 })
 
 describe("copy mode", () => {
+  function createRenderedCopyMode(lines: string[], gutter = 4) {
+    const child = {
+      id: "text-part",
+      y: 0,
+      height: lines.length,
+      gutter: { calculateWidth: () => gutter },
+      getChildren: () => [
+        {
+          _y: 0,
+          plainText: lines.join("\n"),
+          lineInfo: {
+            lineSources: lines.map((_, i) => i),
+            lineStartCols: lines.map(() => 0),
+            lineWidthCols: lines.map((line) => Bun.stringWidth(line)),
+            lineWraps: lines.map(() => 0),
+          },
+        },
+      ],
+    }
+    const scroll = {
+      y: 0,
+      height: 10,
+      width: 120,
+      scrollHeight: lines.length,
+      getChildren: () => [child],
+      scrollBy() {},
+    } as unknown as ScrollBoxRenderable
+    const cm = createCopyMode({
+      scroll: () => scroll,
+      messages: () => [{ id: "message", role: "assistant" }],
+      parts: () => [{ id: "part", type: "text", text: lines.join("\n") }] as Part[],
+      thinking: () => false,
+      details: () => false,
+      session: () => "session",
+      toBottom() {},
+    })
+    cm.prompt.enter()
+    cm.prompt.jump("top")
+    return cm
+  }
+
   test("highlights final wrapped row using its visual slice", () => {
     const child = {
       id: "text-part",
@@ -4287,6 +4328,44 @@ describe("copy mode", () => {
 
     expect(cm.highlights().get("text-part")?.at(-1)).toMatchObject({ line: 2, text: "uvwxyz" })
     expect(cm.prompt.yank()).toEqual({ text: "abcdefghij\nklmnopqrst\nuvwxyz", linewise: false })
+  })
+
+  test("word motions use copy row minimum columns", () => {
+    const cm = createRenderedCopyMode(["alpha beta", "  gamma delta"])
+
+    expect(cm.state().col).toBe(7)
+    expect(cm.prompt.wordNext(false)).toBe(true)
+    expect(cm.state().col).toBe(13)
+    cm.prompt.setCol(13)
+    expect(cm.prompt.wordPrev(false)).toBe(true)
+    expect(cm.state().col).toBe(7)
+    expect(cm.prompt.wordEnd(false)).toBe(true)
+    expect(cm.state().col).toBe(11)
+  })
+
+  test("word motions use target row minimum columns across rows", () => {
+    const cm = createRenderedCopyMode(["alpha beta", "  gamma delta"])
+
+    cm.prompt.setCol(16)
+    expect(cm.prompt.wordNext(false)).toBe(true)
+    expect(cm.state().idx).toBe(1)
+    expect(cm.state().col).toBe(9)
+
+    cm.prompt.jump("top")
+    cm.prompt.setCol(16)
+    expect(cm.prompt.wordEnd(false)).toBe(true)
+    expect(cm.state().idx).toBe(1)
+    expect(cm.state().col).toBe(13)
+  })
+
+  test("b uses previous row minimum columns across rows", () => {
+    const cm = createRenderedCopyMode(["alpha beta", "gamma"])
+    cm.prompt.jump("bottom")
+
+    expect(cm.state().col).toBe(7)
+    expect(cm.prompt.wordPrev(false)).toBe(true)
+    expect(cm.state().idx).toBe(0)
+    expect(cm.state().col).toBe(13)
   })
 
   test("copyWordNext advances to next row when next word is on following line", () => {


### PR DESCRIPTION
Fixes copy-mode w/W, b/B, and e/E to use rendered row start offsets, so word motions land correctly on rows with indentation.
