### PR TITLE
fix: clear copy-mode pending before actions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -996,6 +996,9 @@ export function createVimHandler(input: {
     }
 
     const pending = input.state.pending()
+    const clearCopyPending = () => {
+      if (input.state.pending()) input.state.clearPending()
+    }
     if (pending === "y") {
       input.state.clearPending()
     }
@@ -1025,6 +1028,7 @@ export function createVimHandler(input: {
 
     const scroll = vimScroll(event)
     if (scroll) {
+      clearCopyPending()
       input.scroll(scroll)
       event.preventDefault()
       return true
@@ -1037,33 +1041,41 @@ export function createVimHandler(input: {
       return true
     }
 
-    if (hasModifier(event)) return false
+    if (hasModifier(event)) {
+      clearCopyPending()
+      return false
+    }
 
     if (isShifted(event, "h")) {
+      clearCopyPending()
       input.copyJump?.("high")
       event.preventDefault()
       return true
     }
 
     if (isShifted(event, "m")) {
+      clearCopyPending()
       input.copyJump?.("middle")
       event.preventDefault()
       return true
     }
 
     if (isShifted(event, "l")) {
+      clearCopyPending()
       input.copyJump?.("low")
       event.preventDefault()
       return true
     }
 
     if (isShifted(event, "v")) {
+      clearCopyPending()
       input.copyVisual?.("line")
       event.preventDefault()
       return true
     }
 
     if (key === "v" && !event.shift) {
+      clearCopyPending()
       input.copyVisual?.("char")
       event.preventDefault()
       return true

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -4984,6 +4984,51 @@ describe("copy mode", () => {
     expect(ctx.copyJumps).toEqual(["high", "middle", "low"])
   })
 
+  test("copy jump clears pending find", () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { text: "alpha beta kappa", col: 0 } })
+
+    ctx.handler.handleKey(createEvent("f").event)
+    expect(ctx.state.pending()).toBe("f")
+
+    ctx.handler.handleKey(createEvent("H").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.copyJumps).toEqual(["high"])
+
+    ctx.handler.handleKey(createEvent("k").event)
+    expect(ctx.copyMoves).toEqual(["up"])
+    expect(ctx.state.lastFind()).toBe(null)
+  })
+
+  test("copy jump clears pending scroll", () => {
+    const ctx = createHandler("abc", { mode: "copy" })
+
+    ctx.handler.handleKey(createEvent("z").event)
+    expect(ctx.state.pending()).toBe("z")
+
+    ctx.handler.handleKey(createEvent("H").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.copyJumps).toEqual(["high"])
+
+    ctx.handler.handleKey(createEvent("z").event)
+    expect(ctx.state.pending()).toBe("z")
+    expect(ctx.copyScrollCalls).toEqual([])
+  })
+
+  test("copy visual clears pending find", () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { text: "alpha beta", col: 0 } })
+
+    ctx.handler.handleKey(createEvent("f").event)
+    expect(ctx.state.pending()).toBe("f")
+
+    ctx.handler.handleKey(createEvent("v").event)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.copyVisualCalls).toEqual(["char"])
+
+    ctx.handler.handleKey(createEvent("b").event)
+    expect(ctx.copyCol()).toBe(0)
+    expect(ctx.state.lastFind()).toBe(null)
+  })
+
   test("z sets pending, zz dispatches center scroll", () => {
     const ctx = createHandler("abc", { mode: "copy" })
 


### PR DESCRIPTION
Clears stale copy-mode f/F/t/T and z pending state before unrelated actions.
