### PR TITLE
fix: replace last vim prompt character

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -277,8 +277,8 @@ export function createVimHandler(input: {
       if (next !== null) {
         edit(() => {
           const offset = input.textarea().cursorOffset
-          const reg = deleteUnderCursor(input.textarea())
-          if (reg) {
+          if (deleteUnderCursor(input.textarea())) {
+            input.textarea().cursorOffset = offset
             input.textarea().insertText(next)
             input.textarea().cursorOffset = next === "\n" ? offset + 1 : offset
           }

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -1611,6 +1611,18 @@ describe("vim motion handler", () => {
     expect(ctx.state.mode()).toBe("normal")
   })
 
+  test("r replaces last character without moving left", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 2
+
+    ctx.handler.handleKey(createEvent("r").event)
+    ctx.handler.handleKey(createEvent("d").event)
+
+    expect(ctx.textarea.plainText).toBe("abd")
+    expect(ctx.textarea.cursorOffset).toBe(2)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
   test("r return replaces character with newline and moves to next line", () => {
     const ctx = createHandler("abcd")
     ctx.textarea.cursorOffset = 1


### PR DESCRIPTION
* keep single-character replace anchored at the original cursor position
* add regression coverage for replacing the final prompt character

before this fix:

* line is `abc`
* go to `c`
* do `r` and replace with `d`
* line becomes `adb`