### PR TITLE
fix: preserve scroll after copy mode copy actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Works similarly to tmux copy mode within opencode tui.
 - Press `v` / `V` to start character-wise or line-wise selection.
 - `y/yy` yanks to the vim register.
 - `Enter` copies to the system clipboard.
-- `Escape` exits visual mode, `q` exits copy mode.
-- Press `i` to exit copy mode and focus the prompt input in insert mode without moving the cursor position in copy mode.
+- `Escape` exits visual mode, `q` exits copy mode and scrolls to the bottom.
+- `i` focuses the prompt input.
 - `z` `zt` `zz` `zb` adjust copy-mode scroll positioning.
 - `H` / `M` / `L` jump to the top / middle / bottom of the viewport.
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -85,6 +85,7 @@ export type PromptProps = {
   copy?: {
     enter: () => void
     exit: () => void
+    exitPreserveScroll: () => void
     focusInput: () => void
     visual: (mode: "char" | "line") => void
     yank: () => { text: string; linewise: boolean } | null
@@ -641,8 +642,8 @@ export function Prompt(props: PromptProps) {
     copyExitVisual() {
       props.copy?.exitVisual()
     },
-    copyExit() {
-      props.copy?.exit()
+    copyExitPreserveScroll() {
+      props.copy?.exitPreserveScroll()
     },
     copyFocusInput() {
       props.copy?.focusInput()
@@ -1765,7 +1766,7 @@ export function Prompt(props: PromptProps) {
                   if (vimState.isCopy()) {
                     const active = vimState.isCopy()
                     vim.handleKey(e)
-                    if (active && vimState.mode() === "normal") props.copy?.exit()
+                    if (active && vimState.mode() === "normal" && props.copy?.active()) props.copy.exit()
                     if (!e.defaultPrevented) e.preventDefault()
                     return
                   }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -85,7 +85,7 @@ export function createVimHandler(input: {
   copy?: (action: VimCopyMove) => void
   copyVisual?: (mode: "char" | "line") => void
   copyExitVisual?: () => void
-  copyExit?: () => void
+  copyExitPreserveScroll?: () => void
   copyFocusInput?: () => void
   copyYank?: () => void
   copyYankLine?: () => void
@@ -1046,6 +1046,7 @@ export function createVimHandler(input: {
     if (key === "y") {
       if (input.copyIsVisual?.()) {
         input.copyYank?.()
+        input.copyExitPreserveScroll?.()
         input.state.setMode("normal")
         event.preventDefault()
         return true
@@ -1054,8 +1055,8 @@ export function createVimHandler(input: {
         input.state.clearPending()
         input.copyYankLine?.()
         setTimeout(() => {
+          input.copyExitPreserveScroll?.()
           input.state.setMode("normal")
-          input.copyExit?.()
         }, 70)
         event.preventDefault()
         return true
@@ -1075,6 +1076,7 @@ export function createVimHandler(input: {
 
     if (key === "return") {
       input.copyCopy?.()
+      input.copyExitPreserveScroll?.()
       input.state.setMode("normal")
       event.preventDefault()
       return true

--- a/packages/opencode/src/cli/cmd/tui/routes/session/copy-mode.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/copy-mode.ts
@@ -370,8 +370,12 @@ export function createCopyMode(input: {
     input.toBottom()
   }
 
-  function focusInput() {
+  function exitPreserveScroll() {
     setState((s) => ({ ...s, active: false, visual: undefined, anchor: undefined }))
+  }
+
+  function focusInput() {
+    exitPreserveScroll()
   }
 
   function move(action: "up" | "down" | "left" | "right") {
@@ -751,6 +755,7 @@ export function createCopyMode(input: {
     prompt: {
       enter,
       exit,
+      exitPreserveScroll,
       focusInput,
       visual,
       yank,

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -192,6 +192,7 @@ function createHandler(
   let copyYankLines = 0
   let copyCopies = 0
   let copyExitVisuals = 0
+  let copyExitPreserveScrolls = 0
   let copyFocusInputs = 0
 
   function clearPending() {
@@ -307,6 +308,10 @@ function createHandler(
       copyExitVisuals++
       setCopyVisual(undefined)
     },
+    copyExitPreserveScroll() {
+      copyExitPreserveScrolls++
+      setCopyVisual(undefined)
+    },
     copyFocusInput() {
       copyFocusInputs++
     },
@@ -411,6 +416,7 @@ function createHandler(
     copyYankLines: () => copyYankLines,
     copyCopies: () => copyCopies,
     copyExitVisuals: () => copyExitVisuals,
+    copyExitPreserveScrolls: () => copyExitPreserveScrolls,
     copyFocusInputs: () => copyFocusInputs,
     copyCol,
     copyIdx,
@@ -5099,6 +5105,7 @@ describe("copy mode", () => {
     expect(evt.prevented()).toBe(true)
     expect(ctx.copyYanks()).toBe(1)
     expect(ctx.copyCopies()).toBe(0)
+    expect(ctx.copyExitPreserveScrolls()).toBe(1)
     expect(ctx.state.register()).toEqual({ text: "picked text", linewise: false })
     expect(ctx.state.mode()).toBe("normal")
   })
@@ -5122,6 +5129,7 @@ describe("copy mode", () => {
     expect(ctx.state.pending()).toBe("")
 
     await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(ctx.copyExitPreserveScrolls()).toBe(1)
     expect(ctx.state.mode()).toBe("normal")
   })
 
@@ -5148,6 +5156,7 @@ describe("copy mode", () => {
     expect(evt.prevented()).toBe(true)
     expect(ctx.copyCopies()).toBe(1)
     expect(ctx.copyYanks()).toBe(0)
+    expect(ctx.copyExitPreserveScrolls()).toBe(1)
     expect(ctx.state.mode()).toBe("normal")
   })
 


### PR DESCRIPTION
Preserve scroll positon after `y` and `enter` copy mode like in #103 