### PR TITLE
feat: add copy actions that return to bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Works similarly to tmux copy mode within opencode tui.
 - Press `v` / `V` to start character-wise or line-wise selection.
 - `y/yy` yanks to the vim register.
 - `Enter` copies to the system clipboard.
+- `Y` yanks to the vim register and scrolls to the bottom.
+- `Shift+Enter` copies to the system clipboard and scrolls to the bottom.
 - `Escape` exits visual mode, `q` exits copy mode and scrolls to the bottom.
 - `i` focuses the prompt input.
 - `z` `zt` `zz` `zb` adjust copy-mode scroll positioning.

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -642,6 +642,9 @@ export function Prompt(props: PromptProps) {
     copyExitVisual() {
       props.copy?.exitVisual()
     },
+    copyExit() {
+      props.copy?.exit()
+    },
     copyExitPreserveScroll() {
       props.copy?.exitPreserveScroll()
     },

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -85,6 +85,7 @@ export function createVimHandler(input: {
   copy?: (action: VimCopyMove) => void
   copyVisual?: (mode: "char" | "line") => void
   copyExitVisual?: () => void
+  copyExit?: () => void
   copyExitPreserveScroll?: () => void
   copyFocusInput?: () => void
   copyYank?: () => void
@@ -1043,6 +1044,23 @@ export function createVimHandler(input: {
   }
 
   function copy(event: VimEvent, key: string): boolean {
+    if (input.state.pending() === "" && isShifted(event, "y") && !hasModifier(event)) {
+      if (input.copyIsVisual?.()) {
+        input.copyYank?.()
+        input.state.setMode("normal")
+        input.copyExit?.()
+        event.preventDefault()
+        return true
+      }
+      input.copyYankLine?.()
+      setTimeout(() => {
+        input.state.setMode("normal")
+        input.copyExit?.()
+      }, 70)
+      event.preventDefault()
+      return true
+    }
+
     if (key === "y") {
       if (input.copyIsVisual?.()) {
         input.copyYank?.()
@@ -1076,6 +1094,12 @@ export function createVimHandler(input: {
 
     if (key === "return") {
       input.copyCopy?.()
+      if (event.shift) {
+        input.state.setMode("normal")
+        input.copyExit?.()
+        event.preventDefault()
+        return true
+      }
       input.copyExitPreserveScroll?.()
       input.state.setMode("normal")
       event.preventDefault()

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -192,6 +192,7 @@ function createHandler(
   let copyYankLines = 0
   let copyCopies = 0
   let copyExitVisuals = 0
+  let copyExits = 0
   let copyExitPreserveScrolls = 0
   let copyFocusInputs = 0
 
@@ -308,6 +309,10 @@ function createHandler(
       copyExitVisuals++
       setCopyVisual(undefined)
     },
+    copyExit() {
+      copyExits++
+      setCopyVisual(undefined)
+    },
     copyExitPreserveScroll() {
       copyExitPreserveScrolls++
       setCopyVisual(undefined)
@@ -416,6 +421,7 @@ function createHandler(
     copyYankLines: () => copyYankLines,
     copyCopies: () => copyCopies,
     copyExitVisuals: () => copyExitVisuals,
+    copyExits: () => copyExits,
     copyExitPreserveScrolls: () => copyExitPreserveScrolls,
     copyFocusInputs: () => copyFocusInputs,
     copyCol,
@@ -5133,6 +5139,35 @@ describe("copy mode", () => {
     expect(ctx.state.mode()).toBe("normal")
   })
 
+  test("Y yanks current line and exits copy mode to bottom", async () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { text: "picked line" } })
+
+    const evt = createEvent("Y")
+    expect(ctx.handler.handleKey(evt.event)).toBe(true)
+    expect(evt.prevented()).toBe(true)
+    expect(ctx.copyYankLines()).toBe(1)
+    expect(ctx.copyYanks()).toBe(0)
+    expect(ctx.copyExitPreserveScrolls()).toBe(0)
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(ctx.copyExits()).toBe(1)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("Y yanks visual copy selection and exits copy mode to bottom", () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { text: "picked text", isVisual: true } })
+
+    const evt = createEvent("Y")
+    expect(ctx.handler.handleKey(evt.event)).toBe(true)
+    expect(evt.prevented()).toBe(true)
+    expect(ctx.copyYanks()).toBe(1)
+    expect(ctx.copyYankLines()).toBe(0)
+    expect(ctx.copyExits()).toBe(1)
+    expect(ctx.copyExitPreserveScrolls()).toBe(0)
+    expect(ctx.state.register()).toEqual({ text: "picked text", linewise: false })
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
   test("y H y in copy mode should not trigger yy", () => {
     const ctx = createHandler("abc", { mode: "copy" })
 
@@ -5157,6 +5192,19 @@ describe("copy mode", () => {
     expect(ctx.copyCopies()).toBe(1)
     expect(ctx.copyYanks()).toBe(0)
     expect(ctx.copyExitPreserveScrolls()).toBe(1)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("shift+return copies selection to clipboard path and exits copy mode to bottom", () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { isVisual: true } })
+
+    const evt = createEvent("return", { shift: true })
+    expect(ctx.handler.handleKey(evt.event)).toBe(true)
+    expect(evt.prevented()).toBe(true)
+    expect(ctx.copyCopies()).toBe(1)
+    expect(ctx.copyYanks()).toBe(0)
+    expect(ctx.copyExits()).toBe(1)
+    expect(ctx.copyExitPreserveScrolls()).toBe(0)
     expect(ctx.state.mode()).toBe("normal")
   })
 


### PR DESCRIPTION
Related to #103 and #104

adds `Y` and `shift+enter` in copy to copy and scroll to bottom. 