### PR TITLE
fix: restore ctrl-w copy mode shortcuts after the upstream keymap migration

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -71,7 +71,7 @@ import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/pro
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { type WorkspaceStatus } from "../workspace-label"
 import { useCommandPalette } from "../../context/command-palette"
-import { useBindings, useCommandShortcut, useLeaderActive, useOpencodeKeymap } from "../../keymap"
+import { useBindings, useCommandShortcut, useLeaderActive, useOpencodeKeymap, VIM_WINDOW_TOKEN } from "../../keymap"
 
 export type PromptProps = {
   sessionID?: string
@@ -1101,6 +1101,59 @@ export function Prompt(props: PromptProps) {
       "session.copy_mode",
       "workspace.set",
     ]),
+  }))
+
+  useBindings(() => ({
+    target: inputTarget,
+    priority: 100,
+    enabled:
+      inputTarget() !== undefined &&
+      !props.disabled &&
+      vimEnabled() &&
+      store.mode === "normal" &&
+      !vimState.isInsert() &&
+      !vimState.isReplace() &&
+      !!props.copy,
+    bindings: [
+      {
+        key: `<${VIM_WINDOW_TOKEN}>k`,
+        desc: "Enter copy mode",
+        group: "Session",
+        cmd: () => {
+          if (vimState.isCopy()) return false
+          vimState.setMode("copy")
+          props.copy?.enter()
+          dialog.clear()
+        },
+      },
+      {
+        key: `<${VIM_WINDOW_TOKEN}>w,<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>`,
+        desc: "Toggle copy mode",
+        group: "Session",
+        cmd: () => {
+          if (vimState.isCopy()) {
+            vimState.setMode("normal")
+            props.copy?.exit(false)
+            dialog.clear()
+            return
+          }
+          vimState.setMode("copy")
+          props.copy?.enter()
+          dialog.clear()
+        },
+      },
+      {
+        key: `<${VIM_WINDOW_TOKEN}>j`,
+        desc: "Exit copy mode",
+        group: "Session",
+        cmd: () => {
+          if (!vimState.isCopy()) return false
+          vimState.setMode("normal")
+          props.copy?.exit(false)
+          dialog.clear()
+        },
+      },
+    ],
   }))
 
   const ref: PromptRef = {

--- a/packages/opencode/src/cli/cmd/tui/keymap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/keymap.tsx
@@ -18,6 +18,7 @@ import { useTuiConfig } from "./context/tui-config"
 import { TuiKeybind } from "./config/keybind"
 
 export const LEADER_TOKEN = "leader"
+export const VIM_WINDOW_TOKEN = "vim-window"
 
 export const OpencodeKeymapProvider = KeymapProvider
 export const useOpencodeKeymap = useKeymap
@@ -133,6 +134,7 @@ export function registerOpencodeKeymap(
     name: LEADER_TOKEN,
     timeoutMs: config.leader_timeout,
   })
+  const offVimWindow = keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
   const offEscape = addons.registerEscapeClearsPendingSequence(keymap)
   const offBackspace = addons.registerBackspacePopsPendingSequence(keymap)
   const offInputBindings = addons.registerManagedTextareaLayer(keymap, renderer, {
@@ -145,6 +147,7 @@ export function registerOpencodeKeymap(
     offBackspace()
     offEscape()
     offLeader()
+    offVimWindow()
     offAliasExpander()
     offBaseLayout()
     offCommaBindings()

--- a/packages/opencode/test/cli/cmd/tui/keymap.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/keymap.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import { VIM_WINDOW_TOKEN } from "../../../../src/cli/cmd/tui/keymap"
+
+describe("opencode keymap", () => {
+  test("vim window token sequences can override exact ctrl+w input bindings by priority", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+
+    testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
+    testKeymap.keymap.registerLayer({
+      bindings: [{ key: "ctrl+w", cmd: () => void calls.push("delete-word-backward") }],
+    })
+    testKeymap.keymap.registerLayer({
+      priority: 100,
+      bindings: [{ key: `<${VIM_WINDOW_TOKEN}>k`, cmd: () => void calls.push("copy-mode") }],
+    })
+
+    testKeymap.host.press("w", { ctrl: true })
+    expect(calls).toEqual([])
+    expect(testKeymap.keymap.getPendingSequence().map((item) => item.display)).toEqual([`<${VIM_WINDOW_TOKEN}>`])
+
+    testKeymap.host.press("k")
+    expect(calls).toEqual(["copy-mode"])
+  })
+
+  test("vim window token supports holding ctrl for the second w", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+
+    testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
+    testKeymap.keymap.registerLayer({
+      bindings: [{ key: "ctrl+w", cmd: () => void calls.push("delete-word-backward") }],
+    })
+    testKeymap.keymap.registerLayer({
+      priority: 100,
+      bindings: [{ key: `<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>`, cmd: () => void calls.push("toggle-copy") }],
+    })
+
+    testKeymap.host.press("w", { ctrl: true })
+    testKeymap.host.press("w", { ctrl: true })
+
+    expect(calls).toEqual(["toggle-copy"])
+    expect(testKeymap.keymap.getPendingSequence()).toEqual([])
+  })
+})


### PR DESCRIPTION
 - Restore ctrl-w copy mode shortcuts after the upstream keymap migration
 - Add a vim-window keymap token for ctrl-w so it can act as a sequence prefix instead of being consumed by the textarea delete-word-backward binding
 - Keeps insert-mode ctrl-w behavior 
