### PR TITLE
fix: suspend prompt editing in copy mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1235,6 +1235,30 @@ export function Prompt(props: PromptProps) {
     }
   })
 
+  const copyModeSuspend = { owns: false, previous: false }
+  const restoreCopyModeSuspend = () => {
+    if (!copyModeSuspend.owns || !input || input.isDestroyed) return
+    const traits = { ...input.traits }
+    if (copyModeSuspend.previous) traits.suspend = true
+    else delete traits.suspend
+    input.traits = traits
+    copyModeSuspend.owns = false
+  }
+
+  createEffect(() => {
+    if (!input || input.isDestroyed) return
+    if (!vimState.isCopy()) {
+      restoreCopyModeSuspend()
+      return
+    }
+    if (!copyModeSuspend.owns) {
+      copyModeSuspend.previous = input.traits.suspend === true
+      copyModeSuspend.owns = true
+    }
+    if (input.traits.suspend !== true) input.traits = { ...input.traits, suspend: true }
+  })
+  onCleanup(restoreCopyModeSuspend)
+
   function submitFromTextarea() {
     if (store.mode !== "normal") {
       submit()


### PR DESCRIPTION
   - Suspend prompt textarea editing while in copy mode 
   - Prevent scroll/input escape bytes from mutating the focused prompt during copy mode
   - Restore the previous textarea suspend state when leaving copy mode
