### PR TITLE
fix: restore normal mode autocomplete triggers

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -74,6 +74,8 @@ export type VimEvent = {
   ctrl?: boolean
   meta?: boolean
   super?: boolean
+  sequence?: string
+  raw?: string
   preventDefault: () => void
 }
 
@@ -122,6 +124,14 @@ export function createVimHandler(input: {
 
   function hasModifier(event: VimEvent) {
     return !!event.ctrl || !!event.meta || !!event.super
+  }
+
+  function normalizedKeyName(event: VimEvent) {
+    if (event.name === "slash") return "/"
+    if (event.name === "at") return "@"
+    const text = event.sequence?.length === 1 ? event.sequence : event.raw?.length === 1 ? event.raw : undefined
+    if (text === "/" || text === "@") return text
+    return event.name ?? ""
   }
 
   function isPrintable(event: VimEvent) {
@@ -742,9 +752,11 @@ export function createVimHandler(input: {
     }
 
     if ((key === "/" || key === "@") && !hasModifier(event)) {
-      if (input.autocomplete?.() && input.textarea().cursorOffset === 0 && input.textarea().plainText.length === 0) {
+      if (input.autocomplete && input.textarea().cursorOffset === 0 && input.textarea().plainText.length === 0) {
         input.state.setMode("insert")
-        return false
+        input.textarea().insertText(key)
+        event.preventDefault()
+        return true
       }
       event.preventDefault()
       return true
@@ -1525,7 +1537,7 @@ export function createVimHandler(input: {
       }
 
       if (input.state.isCopy()) {
-        return copy(event, event.name ?? "")
+        return copy(event, normalizedKeyName(event))
       }
 
       if (input.state.isInsert()) {
@@ -1537,7 +1549,7 @@ export function createVimHandler(input: {
         return true
       }
 
-      const key = event.name ?? ""
+      const key = normalizedKeyName(event)
       const result = dispatch(event, key)
 
       if (result && input.state.isVisual()) {

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -121,7 +121,10 @@ function createTextarea(text: string, opts?: { strict?: boolean }) {
   return textarea as unknown as TextareaRenderable
 }
 
-function createEvent(name: string, options?: { shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean }) {
+function createEvent(
+  name: string,
+  options?: { shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean; sequence?: string; raw?: string },
+) {
   let prevented = false
   return {
     event: {
@@ -130,6 +133,8 @@ function createEvent(name: string, options?: { shift?: boolean; ctrl?: boolean; 
       ctrl: options?.ctrl,
       meta: options?.meta,
       super: options?.super,
+      sequence: options?.sequence,
+      raw: options?.raw,
       preventDefault() {
         prevented = true
       },
@@ -2021,28 +2026,56 @@ describe("vim motion handler", () => {
     expect(ctx.state.mode()).toBe("normal")
   })
 
-  test("/ enters insert on empty input with autocomplete visible", () => {
+  test("/ enters insert on empty input with autocomplete available", () => {
     const ctx = createHandler("", {
       mode: "normal",
-      autocomplete: () => "/",
+      autocomplete: () => false,
     })
     const slash = createEvent("/")
 
-    expect(ctx.handler.handleKey(slash.event)).toBe(false)
-    expect(slash.prevented()).toBe(false)
+    expect(ctx.handler.handleKey(slash.event)).toBe(true)
+    expect(slash.prevented()).toBe(true)
     expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("/")
   })
 
-  test("@ enters insert on empty input with autocomplete visible", () => {
+  test("@ enters insert on empty input with autocomplete available", () => {
     const ctx = createHandler("", {
       mode: "normal",
-      autocomplete: () => "@",
+      autocomplete: () => false,
     })
     const at = createEvent("@")
 
-    expect(ctx.handler.handleKey(at.event)).toBe(false)
-    expect(at.prevented()).toBe(false)
+    expect(ctx.handler.handleKey(at.event)).toBe(true)
+    expect(at.prevented()).toBe(true)
     expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("@")
+  })
+
+  test("/ enters insert when OpenTUI reports the key name as slash", () => {
+    const ctx = createHandler("", {
+      mode: "normal",
+      autocomplete: () => false,
+    })
+    const slash = createEvent("slash")
+
+    expect(ctx.handler.handleKey(slash.event)).toBe(true)
+    expect(slash.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("/")
+  })
+
+  test("@ enters insert when OpenTUI reports the shifted base key", () => {
+    const ctx = createHandler("", {
+      mode: "normal",
+      autocomplete: () => false,
+    })
+    const at = createEvent("2", { shift: true, sequence: "@" })
+
+    expect(ctx.handler.handleKey(at.event)).toBe(true)
+    expect(at.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("@")
   })
 
   test("/ stays normal on non-empty input with autocomplete visible", () => {


### PR DESCRIPTION
   - Restore Vim normal-mode `/` and `@` autocomplete triggers on an empty prompt
   - Normalize OpenTUI key names for slash/at variants
