### PR TITLE
feat: add vim dot repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Toggle via command palette (`Ctrl+p` -> `Toggle vim mode`).
 
 `i` `I` `a` `A` `o` `O` `R` `r` `x` `~` `dd` `dw` `db` `d%` `d}` `d{` `cc` `cw` `cb` `C` `c%` `c}` `c{` `S` `J`
 
-**yank / put / undo**
+**yank / put / undo / repeat**
 
-`yy` `yw` `y%` `y}` `y{` `p` `P` `u` `ctrl+r`
+`yy` `yw` `y%` `y}` `y{` `p` `P` `u` `ctrl+r` `.`
 
 - Copy the current prompt selection with `<leader>y` (default: `ctrl+x` then `y`).
 - Configure it with `keybinds.prompt_copy_selection`.

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -752,6 +752,7 @@ export function Prompt(props: PromptProps) {
     autocomplete: () => auto()?.visible ?? false,
     history: () => true,
     snapshot: promptSnapshot,
+    snapshotDataEqual: promptPartDataEqual,
     restore(next) {
       input.setText(next.text)
       input.cursorOffset = Math.max(0, Math.min(next.cursor, next.text.length))
@@ -907,6 +908,7 @@ export function Prompt(props: PromptProps) {
           }
           if (vimEnabled() && store.mode === "normal" && vimState.mode() !== "normal") {
             if (vimState.isVisual()) clearSelection(input)
+            vimState.cancelEdit()
             vimState.setMode("normal")
             setStore("interrupt", 0)
             dialog.clear()
@@ -1786,6 +1788,38 @@ export function Prompt(props: PromptProps) {
       cursor: input.cursorOffset,
       data: structuredClone(unwrap(store.prompt.parts)),
     }
+  }
+
+  function promptPartDataEqual(before: unknown, after: unknown) {
+    if (!Array.isArray(before) || !Array.isArray(after)) return Bun.deepEquals(before, after)
+    return Bun.deepEquals(before.map(normalizePromptPartForRepeat), after.map(normalizePromptPartForRepeat))
+  }
+
+  function normalizePromptPartForRepeat(part: PromptInfo["parts"][number]) {
+    if (part.type === "agent" && part.source) {
+      return {
+        ...part,
+        source: {
+          ...part.source,
+          start: 0,
+          end: 0,
+        },
+      }
+    }
+    if ((part.type === "file" || part.type === "text") && part.source?.text) {
+      return {
+        ...part,
+        source: {
+          ...part.source,
+          text: {
+            ...part.source.text,
+            start: 0,
+            end: 0,
+          },
+        },
+      }
+    }
+    return part
   }
 
   function pasteText(text: string, virtualText: string) {

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -4,6 +4,7 @@ import type { TextareaRenderable } from "@opentui/core"
 import { vimScroll, type VimScroll } from "./vim-scroll"
 import { vimJump, type VimJump } from "./vim-motion-jump"
 import { vimWindowNavigation, type VimWindowNavigation } from "./vim-motion-window-navigation"
+import { createVimRepeat } from "./vim-repeat"
 import {
   appendAfterCursor,
   appendLineEnd,
@@ -116,6 +117,7 @@ export function createVimHandler(input: {
   flash?: (span: { start: number; end: number }) => void
   history?: () => boolean
   snapshot?: () => VimSnapshot
+  snapshotDataEqual?: (before: unknown, after: unknown) => boolean
   restore?: (next: VimSnapshot) => void
   register?: () => VimRegister
   setRegister?: (register: VimRegister, notify?: boolean) => void
@@ -183,7 +185,8 @@ export function createVimHandler(input: {
   }
 
   function preservesWantedColumn(event: VimEvent, key: string) {
-    if ((key === "j" || key === "k" || key === "down" || key === "up") && !event.shift && !hasModifier(event)) return true
+    if ((key === "j" || key === "k" || key === "down" || key === "up") && !event.shift && !hasModifier(event))
+      return true
     return (key === "v" || isShifted(event, "v")) && !hasModifier(event)
   }
 
@@ -209,54 +212,64 @@ export function createVimHandler(input: {
     input.textarea().cursorOffset = Math.max(0, Math.min(next.cursor, next.text.length))
   }
 
-  function edit(run: () => void) {
-    if (!tracked()) {
-      run()
-      return
-    }
-    const before = snapshot()
-    run()
-    input.state.push(before, snapshot())
-  }
+  const repeat = createVimRepeat({
+    state: input.state,
+    textarea: input.textarea,
+    snapshot,
+    snapshotDataEqual: input.snapshotDataEqual,
+    tracked,
+  })
+  const edit = repeat.edit
+  const begin = repeat.begin
 
-  function begin(run?: () => void) {
-    if (!tracked()) {
-      run?.()
-      return
-    }
-    input.state.beginEdit(snapshot())
-    run?.()
-  }
-
-  function applyParagraphYank(result: ParagraphResult) {
+  function applyOperatorYank(result: ParagraphResult) {
     if (result.register) setRegister(result.register, true)
     if (result.span && result.span.end > result.span.start) input.flash?.(result.span)
     input.state.clearPending()
   }
 
-  function applyParagraphEdit(textarea: TextareaRenderable, result: ParagraphResult, operation: "d" | "c") {
+  function applyOperatorEdit(result: () => ParagraphResult, operation: "d" | "c") {
     const apply = () => {
-      if (result.span) deleteSpan(textarea, result.span)
-      if (result.register) setRegister(result.register)
+      const next = result()
+      if (!next.span && !next.register) {
+        input.state.clearPending()
+        return false
+      }
+      if (next.span) deleteSpan(input.textarea(), next.span)
+      if (next.register) setRegister(next.register)
       input.state.clearPending()
       if (operation === "c") input.state.setMode("insert")
+      return true
     }
     if (operation === "c") begin(apply)
     else edit(apply)
   }
 
+  function applyOperatorResult(result: () => ParagraphResult, operation: ParagraphOperation) {
+    const initial = result()
+
+    // no motion: vim no-ops the operator without editing or changing mode.
+    if (!initial.span && !initial.register) {
+      input.state.clearPending()
+      return
+    }
+    if (operation === "y") {
+      applyOperatorYank(initial)
+      return
+    }
+    applyOperatorEdit(result, operation)
+  }
+
   function paragraphOperator(key: string, operation: ParagraphOperation): boolean {
     if (key !== "{" && key !== "}") return false
 
-    const textarea = input.textarea()
-
-    const result =
-      key === "}" ? nextParagraphOperation(textarea, operation) : previousParagraphOperation(textarea, operation)
-
-    // no motion: vim no-ops the operator without editing or changing mode.
-    if (!result.span && !result.register) input.state.clearPending()
-    else if (operation === "y") applyParagraphYank(result)
-    else applyParagraphEdit(textarea, result, operation)
+    applyOperatorResult(
+      () =>
+        key === "}"
+          ? nextParagraphOperation(input.textarea(), operation)
+          : previousParagraphOperation(input.textarea(), operation),
+      operation,
+    )
 
     return true
   }
@@ -264,11 +277,7 @@ export function createVimHandler(input: {
   function matchingBracketOperator(key: string, operation: ParagraphOperation): boolean {
     if (key !== "%") return false
 
-    const textarea = input.textarea()
-    const result = matchingBracketOperation(textarea)
-    if (!result.span && !result.register) input.state.clearPending()
-    else if (operation === "y") applyParagraphYank(result)
-    else applyParagraphEdit(textarea, result, operation)
+    applyOperatorResult(() => matchingBracketOperation(input.textarea()), operation)
 
     return true
   }
@@ -277,6 +286,17 @@ export function createVimHandler(input: {
     const textarea = input.textarea()
     const char = textarea.plainText[textarea.cursorOffset]
     return char && !/\s/.test(char) ? deleteWordEnd(textarea, big) : deleteWord(textarea)
+  }
+
+  function beginChangeWord(result: () => VimRegister) {
+    begin(() => {
+      const reg = result()
+      input.state.clearPending()
+      if (!reg) return false
+      setRegister(reg)
+      input.state.setMode("insert")
+      return true
+    })
   }
 
   function undo() {
@@ -312,6 +332,8 @@ export function createVimHandler(input: {
             input.textarea().cursorOffset = offset
             input.textarea().insertText(next)
             input.textarea().cursorOffset = next === "\n" ? offset + 1 : offset
+            input.state.clearPending()
+            return true
           }
           input.state.clearPending()
         })
@@ -388,13 +410,28 @@ export function createVimHandler(input: {
       return true
     }
 
+    if (key === "." && !event.shift && !hasModifier(event) && !input.state.isVisual() && !input.state.pending()) {
+      const repeat = input.state.repeat()
+      if (repeat) repeat.run()
+      event.preventDefault()
+      return true
+    }
+
     if (key === "u" && !event.shift && !hasModifier(event) && !input.state.isVisual() && !input.state.pending()) {
       undo()
       event.preventDefault()
       return true
     }
 
-    if (key === "r" && !!event.ctrl && !event.shift && !event.meta && !event.super && !input.state.isVisual() && !input.state.pending()) {
+    if (
+      key === "r" &&
+      !!event.ctrl &&
+      !event.shift &&
+      !event.meta &&
+      !event.super &&
+      !input.state.isVisual() &&
+      !input.state.pending()
+    ) {
       redo()
       event.preventDefault()
       return true
@@ -541,46 +578,26 @@ export function createVimHandler(input: {
       }
 
       if (key === "w" && !event.shift) {
-        begin(() => {
-          const reg = changeWord(false)
-          if (reg) setRegister(reg)
-          input.state.clearPending()
-          input.state.setMode("insert")
-        })
+        beginChangeWord(() => changeWord(false))
         event.preventDefault()
         return true
       }
 
       if (isShifted(event, "w") && !hasModifier(event)) {
-        begin(() => {
-          const reg = changeWord(true)
-          if (reg) setRegister(reg)
-          input.state.clearPending()
-          input.state.setMode("insert")
-        })
+        beginChangeWord(() => changeWord(true))
         event.preventDefault()
         return true
       }
 
       if (key === "b" && !event.shift) {
-        begin(() => {
-          const reg = deleteWordBackward(input.textarea())
-          if (reg) setRegister(reg)
-          input.state.clearPending()
-          input.state.setMode("insert")
-        })
+        beginChangeWord(() => deleteWordBackward(input.textarea()))
         event.preventDefault()
         return true
       }
 
       if ((key === "e" || key === "E") && !hasModifier(event)) {
         const big = key === "E" || !!event.shift
-        begin(() => {
-          const reg = deleteWordEnd(input.textarea(), big)
-          if (reg) setRegister(reg)
-          input.state.clearPending()
-          input.state.setMode("insert")
-        })
+        beginChangeWord(() => deleteWordEnd(input.textarea(), big))
         event.preventDefault()
         return true
       }
@@ -787,16 +804,18 @@ export function createVimHandler(input: {
     }
 
     if (key === "p" && !event.shift && !hasModifier(event)) {
+      const reg = register()
       edit(() => {
-        pasteAfter(input.textarea(), register())
+        pasteAfter(input.textarea(), reg)
       })
       event.preventDefault()
       return true
     }
 
     if (isShifted(event, "p") && !hasModifier(event)) {
+      const reg = register()
       edit(() => {
-        pasteBefore(input.textarea(), register())
+        pasteBefore(input.textarea(), reg)
       })
       event.preventDefault()
       return true
@@ -871,10 +890,14 @@ export function createVimHandler(input: {
     }
 
     if (isShifted(event, "r") && !hasModifier(event)) {
-      begin()
-      input.state.setReplace(input.textarea().cursorOffset)
-      input.state.setTyped(false)
-      input.state.setMode("replace")
+      begin(
+        () => {
+          input.state.setReplace(input.textarea().cursorOffset)
+          input.state.setTyped(false)
+          input.state.setMode("replace")
+        },
+        { replace: true },
+      )
       event.preventDefault()
       return true
     }
@@ -896,8 +919,9 @@ export function createVimHandler(input: {
     }
 
     if (key === "i" && !event.shift && !hasModifier(event)) {
-      begin()
-      input.state.setMode("insert")
+      begin(() => {
+        input.state.setMode("insert")
+      })
       event.preventDefault()
       return true
     }
@@ -1522,12 +1546,15 @@ export function createVimHandler(input: {
             input.textarea().cursorOffset = Math.max(start, input.textarea().cursorOffset - 1)
           }
           input.state.commitEdit(snapshot())
+          repeat.commit(snapshot())
           event.preventDefault()
           return true
         }
 
         if (isPrintable(event) && !hasModifier(event)) {
-          replaceUnderCursor(input.textarea(), value(event))
+          const next = value(event)
+          repeat.recordReplaceChar(next)
+          replaceUnderCursor(input.textarea(), next)
           input.state.setTyped(true)
           event.preventDefault()
           return true
@@ -1545,6 +1572,7 @@ export function createVimHandler(input: {
         input.state.setMode("normal")
         input.state.commitEdit(snapshot())
         moveLeft(input.textarea())
+        repeat.commit(snapshot())
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -1537,6 +1537,12 @@ export function createVimHandler(input: {
     handleKey(event: VimEvent) {
       if (!input.enabled()) return false
 
+      // Keep dot replay atomic
+      if (input.state.replaying()) {
+        event.preventDefault()
+        return true
+      }
+
       if (input.state.isReplace()) {
         if (event.name === "escape") {
           const start = input.state.replace()

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-repeat.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-repeat.ts
@@ -1,0 +1,310 @@
+import type { TextareaRenderable } from "@opentui/core"
+import type { createVimState, VimSnapshot } from "./vim-state"
+import { replaceUnderCursor } from "./vim-motions"
+
+type VimTextPatch = {
+  startOffset: number
+  baseEndOffset: number
+  insert: string
+  cursorOffset: number
+}
+
+type VimTextEdit = Omit<VimTextPatch, "cursorOffset">
+
+type VimRepeatRecorder = {
+  textarea: TextareaRenderable
+  insertText: TextareaRenderable["insertText"]
+  deleteRange: TextareaRenderable["deleteRange"]
+  setText: TextareaRenderable["setText"]
+}
+
+type VimActiveRepeat = {
+  before: VimSnapshot
+  base: VimSnapshot
+  setup: () => boolean | void
+} & ({ type: "patch"; edits: VimTextEdit[]; recorder?: VimRepeatRecorder } | { type: "replace"; chars: string[] })
+
+type VimPatchRepeat = Extract<VimActiveRepeat, { type: "patch" }>
+
+export function createVimRepeat(input: {
+  state: ReturnType<typeof createVimState>
+  textarea: () => TextareaRenderable
+  snapshot: () => VimSnapshot
+  snapshotDataEqual?: (before: unknown, after: unknown) => boolean
+  tracked: () => boolean
+}) {
+  let activeRepeat: VimActiveRepeat | undefined
+  let mutationDepth = 0
+
+  function clampOffset(offset: number, length: number) {
+    return Math.max(0, Math.min(length, offset))
+  }
+
+  function changed(before: VimSnapshot, after: VimSnapshot) {
+    return before.text !== after.text || before.cursor !== after.cursor
+  }
+
+  function sameData(before: VimSnapshot, after: VimSnapshot) {
+    return input.snapshotDataEqual?.(before.data, after.data) ?? Bun.deepEquals(before.data, after.data)
+  }
+
+  function textEdit(origin: VimSnapshot, before: VimSnapshot, after: VimSnapshot): VimTextEdit | null {
+    if (before.text === after.text) return null
+    let commonStart = 0
+    while (
+      commonStart < before.text.length &&
+      commonStart < after.text.length &&
+      before.text[commonStart] === after.text[commonStart]
+    )
+      commonStart++
+    const start = Math.min(commonStart, before.cursor)
+    let baseEnd = before.text.length
+    let afterEnd = after.text.length
+    while (baseEnd > start && afterEnd > start && before.text[baseEnd - 1] === after.text[afterEnd - 1]) {
+      baseEnd--
+      afterEnd--
+    }
+    return {
+      startOffset: start - origin.cursor,
+      baseEndOffset: baseEnd - origin.cursor,
+      insert: after.text.slice(start, afterEnd),
+    }
+  }
+
+  function patch(base: VimSnapshot, after: VimSnapshot): VimTextPatch | null {
+    const edit = textEdit(base, base, after)
+    if (!edit)
+      return {
+        startOffset: 0,
+        baseEndOffset: 0,
+        insert: "",
+        cursorOffset: after.cursor - base.cursor,
+      }
+    const deleted = base.text.slice(base.cursor + edit.startOffset, base.cursor + edit.baseEndOffset)
+    if (deleted && edit.insert.includes(deleted)) return null
+    return {
+      ...edit,
+      cursorOffset: after.cursor - base.cursor,
+    }
+  }
+
+  function applyTextEdit(base: VimSnapshot, next: VimTextEdit) {
+    const textarea = input.textarea()
+    const start = clampOffset(base.cursor + next.startOffset, textarea.plainText.length)
+    const end = Math.max(start, clampOffset(base.cursor + next.baseEndOffset, textarea.plainText.length))
+    if (end > start) {
+      const startPos = textarea.editBuffer.offsetToPosition(start)
+      const endPos = textarea.editBuffer.offsetToPosition(end)
+      if (!startPos || !endPos) return
+      textarea.deleteRange(startPos.row, startPos.col, endPos.row, endPos.col)
+    }
+    textarea.cursorOffset = start
+    if (next.insert) textarea.insertText(next.insert)
+    textarea.cursorOffset = start + next.insert.length
+  }
+
+  function applyPatch(base: VimSnapshot, next: VimTextPatch) {
+    applyTextEdit(base, next)
+    const textarea = input.textarea()
+    textarea.cursorOffset = clampOffset(base.cursor + next.cursorOffset, textarea.plainText.length)
+  }
+
+  function recordTextEdit(active: VimPatchRepeat, before: VimSnapshot) {
+    if (activeRepeat !== active || input.state.replaying()) return
+    const edit = textEdit(active.base, before, input.snapshot())
+    if (edit) active.edits.push(edit)
+  }
+
+  function recordMutation<T>(active: VimPatchRepeat, run: () => T) {
+    if (mutationDepth) return run()
+    const before = input.snapshot()
+    mutationDepth++
+    try {
+      return run()
+    } finally {
+      mutationDepth--
+      recordTextEdit(active, before)
+    }
+  }
+
+  function startRecording(active: VimPatchRepeat) {
+    const textarea = input.textarea()
+    const recorder = {
+      textarea,
+      insertText: textarea.insertText,
+      deleteRange: textarea.deleteRange,
+      setText: textarea.setText,
+    }
+    active.recorder = recorder
+    textarea.insertText = (...args) => {
+      return recordMutation(active, () => recorder.insertText.apply(textarea, args))
+    }
+    textarea.deleteRange = (...args) => {
+      return recordMutation(active, () => recorder.deleteRange.apply(textarea, args))
+    }
+    textarea.setText = (...args) => {
+      return recordMutation(active, () => recorder.setText.apply(textarea, args))
+    }
+  }
+
+  function stopRecording(active: VimActiveRepeat) {
+    if (active.type !== "patch" || !active.recorder) return
+    active.recorder.textarea.insertText = active.recorder.insertText
+    active.recorder.textarea.deleteRange = active.recorder.deleteRange
+    active.recorder.textarea.setText = active.recorder.setText
+    active.recorder = undefined
+  }
+
+  function finishActiveRepeat() {
+    const active = activeRepeat
+    activeRepeat = undefined
+    if (active) stopRecording(active)
+    return active
+  }
+
+  function cancel() {
+    finishActiveRepeat()
+  }
+
+  input.state.onCancelEdit(cancel)
+
+  function applyTextEdits(base: VimSnapshot, edits: VimTextEdit[], cursorOffset: number) {
+    edits.forEach((edit) => applyTextEdit(base, edit))
+    const textarea = input.textarea()
+    textarea.cursorOffset = clampOffset(base.cursor + cursorOffset, textarea.plainText.length)
+  }
+
+  function withReplay(run: () => void) {
+    input.state.setReplaying(true)
+    try {
+      run()
+    } finally {
+      input.state.setReplaying(false)
+    }
+  }
+
+  function pushReplay(before: VimSnapshot, after: VimSnapshot) {
+    if (!sameData(before, after)) input.state.setRepeat(null)
+    if (!changed(before, after)) return false
+    input.state.push(before, after)
+    return true
+  }
+
+  function recordRepeat(run: () => void) {
+    if (input.state.replaying()) return
+    input.state.setRepeat({
+      run() {
+        const before = input.snapshot()
+        withReplay(run)
+        return pushReplay(before, input.snapshot())
+      },
+    })
+  }
+
+  function edit(run: () => boolean | void) {
+    if (!input.tracked()) {
+      run()
+      return
+    }
+    const before = input.snapshot()
+    const repeatable = !input.state.replaying() && !input.state.isVisual()
+    const applied = run() === true
+    const after = input.snapshot()
+    input.state.push(before, after)
+    if (!repeatable) return
+    if (!sameData(before, after)) {
+      input.state.setRepeat(null)
+      return
+    }
+    if (applied || changed(before, after)) recordRepeat(run)
+  }
+
+  function begin(run?: () => boolean | void, options?: { replace?: boolean }) {
+    if (!input.tracked()) {
+      run?.()
+      return
+    }
+    cancel()
+    const before = input.snapshot()
+    const repeatable = !input.state.replaying() && !input.state.isVisual()
+    input.state.beginEdit(before)
+    if (run?.() === false) {
+      input.state.cancelEdit()
+      return
+    }
+    if (repeatable) {
+      const next = {
+        before,
+        base: input.snapshot(),
+        setup: run ?? (() => {}),
+      }
+      activeRepeat = options?.replace ? { ...next, type: "replace", chars: [] } : { ...next, type: "patch", edits: [] }
+      if (activeRepeat.type === "patch") startRecording(activeRepeat)
+    }
+  }
+
+  function commit(after: VimSnapshot) {
+    const active = finishActiveRepeat()
+    if (!active || input.state.replaying()) return
+    if (!sameData(active.before, active.base) || !sameData(active.base, after)) {
+      input.state.setRepeat(null)
+      return
+    }
+    const recordCommittedRepeat = (run: () => void) =>
+      input.state.setRepeat({
+        run() {
+          const before = input.snapshot()
+          let failed = false
+          withReplay(() => {
+            if (active.setup() === false) {
+              failed = true
+              input.state.setMode("normal")
+              return
+            }
+            run()
+            input.state.setMode("normal")
+          })
+          const repeated = input.snapshot()
+          if (failed) return false
+          return pushReplay(before, repeated)
+        },
+      })
+    if (active.type === "replace" && active.chars.length) {
+      recordCommittedRepeat(() => {
+        const start = input.state.replace()
+        active.chars.forEach((char) => replaceUnderCursor(input.textarea(), char))
+        if (start !== null) input.textarea().cursorOffset = Math.max(start, input.textarea().cursorOffset - 1)
+      })
+      return
+    }
+    if (active.type === "replace") {
+      input.state.setRepeat(null)
+      return
+    }
+    if (active.edits.length) {
+      const cursorOffset = after.cursor - active.base.cursor
+      recordCommittedRepeat(() => applyTextEdits(input.snapshot(), active.edits, cursorOffset))
+      return
+    }
+    const next = patch(active.base, after)
+    if (!next) {
+      input.state.setRepeat(null)
+      return
+    }
+    if (active.before.text === active.base.text && active.base.text === after.text && !next.insert) {
+      input.state.setRepeat(null)
+      return
+    }
+    recordCommittedRepeat(() => applyPatch(input.snapshot(), next))
+  }
+
+  return {
+    edit,
+    begin,
+    commit,
+    recordReplaceChar(char: string) {
+      if (activeRepeat?.type === "replace") activeRepeat.chars.push(char)
+    },
+    cancel,
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -5,6 +5,7 @@ export type VimPending = "" | "c" | "d" | "g" | "z" | "f" | "F" | "t" | "T" | "y
 export type VimFind = { char: string; forward: boolean; till: boolean } | null
 export type VimRegister = { text: string; linewise: boolean } | null
 export type VimSnapshot = { text: string; cursor: number; data?: unknown }
+export type VimRepeat = { run: () => boolean }
 
 type VimHistory = {
   before: VimSnapshot
@@ -22,8 +23,11 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
   const [undos, setUndos] = createSignal<VimHistory[]>([])
   const [redos, setRedos] = createSignal<VimSnapshot[]>([])
   const [edit, setEdit] = createSignal<VimSnapshot | null>(null)
+  const [repeat, setRepeat] = createSignal<VimRepeat | null>(null)
+  const [replaying, setReplaying] = createSignal(false)
   const [skipExitOnModeChange, setSkipExitOnModeChange] = createSignal(false)
   const [exitScrollToBottom, setExitScrollToBottom] = createSignal(true)
+  const cancelEditCallbacks = new Set<() => void>()
 
   function clearPending() {
     if (pending()) setPending("")
@@ -33,10 +37,16 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
     setEdit(null)
   }
 
+  function cancelOpenEdit() {
+    cancelEditCallbacks.forEach((callback) => callback())
+    clearEdit()
+  }
+
   function clearHistory() {
+    cancelOpenEdit()
     setUndos([])
     setRedos([])
-    clearEdit()
+    setRepeat(null)
   }
 
   function changeMode(next: VimMode) {
@@ -62,7 +72,7 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
     if (!enabled) {
       if (mode() !== "insert") setMode("insert")
       clearPending()
-      clearEdit()
+      cancelOpenEdit()
       return
     }
   })
@@ -93,8 +103,18 @@ export function createVimState(input: { enabled: Accessor<boolean>; initial?: Ac
       push(start, snapshot)
     },
     cancelEdit() {
-      clearEdit()
+      cancelOpenEdit()
     },
+    onCancelEdit(callback: () => void) {
+      cancelEditCallbacks.add(callback)
+      return () => cancelEditCallbacks.delete(callback)
+    },
+    repeat,
+    setRepeat(next: VimRepeat | null) {
+      setRepeat(next)
+    },
+    replaying,
+    setReplaying,
     push,
     undo(snapshot: VimSnapshot) {
       const item = undos()[undos().length - 1]

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -165,6 +165,7 @@ function createHandler(
       set?: (register: { text: string; linewise: boolean } | null, notify?: boolean) => void
     }
     data?: unknown
+    snapshotDataEqual?: (before: unknown, after: unknown) => boolean
   },
 ) {
   const textarea = createTextarea(text, { strict: options?.strict })
@@ -172,7 +173,9 @@ function createHandler(
   const [mode, setMode] = createSignal<"normal" | "insert" | "replace" | "visual" | "visual-line" | "copy">(
     options?.mode ?? "normal",
   )
-  const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "z" | "f" | "F" | "t" | "T" | "y" | "w" | "r" | "vr">("")
+  const [pending, setPending] = createSignal<
+    "" | "c" | "d" | "g" | "z" | "f" | "F" | "t" | "T" | "y" | "w" | "r" | "vr"
+  >("")
   const [lastFind, setLastFind] = createSignal<{ char: string; forward: boolean; till: boolean } | null>(null)
   const [register, setRegister] = createSignal<{ text: string; linewise: boolean } | null>(null)
   const [anchor, setAnchor] = createSignal<number | null>(null)
@@ -184,9 +187,14 @@ function createHandler(
     options?.copy?.isVisual ? "char" : undefined,
   )
   const [meta, setMeta] = createSignal(options?.data)
-  const [undos, setUndos] = createSignal<Array<{ before: { text: string; cursor: number }; after: { text: string; cursor: number } }>>([])
+  const [undos, setUndos] = createSignal<
+    Array<{ before: { text: string; cursor: number }; after: { text: string; cursor: number } }>
+  >([])
   const [redos, setRedos] = createSignal<Array<{ text: string; cursor: number }>>([])
   const [editState, setEditState] = createSignal<{ text: string; cursor: number } | null>(null)
+  const [repeat, setRepeat] = createSignal<{ run: () => boolean } | null>(null)
+  const [replaying, setReplaying] = createSignal(false)
+  const cancelEditCallbacks = new Set<() => void>()
   const [copyCol, setCopyCol] = createSignal(options?.copy?.col ?? 0)
   const [copyIdx, setCopyIdx] = createSignal(options?.copy?.idx ?? 0)
   const copyRows = options?.copy?.rows
@@ -220,6 +228,11 @@ function createHandler(
     setMode(next)
   }
 
+  function cancelOpenEdit() {
+    cancelEditCallbacks.forEach((callback) => callback())
+    setEditState(null)
+  }
+
   const state: ReturnType<typeof createVimState> = {
     mode,
     setMode: changeMode,
@@ -248,8 +261,18 @@ function createHandler(
       setRedos([])
     },
     cancelEdit() {
-      setEditState(null)
+      cancelOpenEdit()
     },
+    onCancelEdit(callback) {
+      cancelEditCallbacks.add(callback)
+      return () => cancelEditCallbacks.delete(callback)
+    },
+    repeat,
+    setRepeat(next) {
+      setRepeat(next)
+    },
+    replaying,
+    setReplaying,
     push(before, after) {
       setEditState(null)
       if (before.text === after.text && before.cursor === after.cursor) return
@@ -273,9 +296,10 @@ function createHandler(
       return item
     },
     resetHistory() {
+      cancelOpenEdit()
       setUndos([])
       setRedos([])
-      setEditState(null)
+      setRepeat(null)
     },
     canUndo: () => undos().length > 0,
     canRedo: () => redos().length > 0,
@@ -284,9 +308,10 @@ function createHandler(
       setAnchor(null)
       setReplace(null)
       setTyped(false)
+      cancelOpenEdit()
       setUndos([])
       setRedos([])
-      setEditState(null)
+      setRepeat(null)
       setMode("insert")
     },
     isInsert: () => mode() === "insert",
@@ -451,6 +476,7 @@ function createHandler(
         data: structuredClone(meta()),
       }
     },
+    snapshotDataEqual: options?.snapshotDataEqual,
     restore(next) {
       textarea.setText(next.text)
       textarea.cursorOffset = Math.max(0, Math.min(next.cursor, next.text.length))
@@ -4417,6 +4443,674 @@ describe("vim paragraph operator parity", () => {
   })
 })
 
+describe("vim dot repeat", () => {
+  type RepeatFilePart = {
+    type: "file"
+    filename: string
+    source: { type: "file"; path: string; text: { start: number; end: number; value: string } }
+  }
+
+  const repeatFilePartDataEqual = (before: unknown, after: unknown) => {
+    const normalize = (value: unknown) =>
+      Array.isArray(value)
+        ? (value as RepeatFilePart[]).map((part) => ({
+            ...part,
+            source: {
+              ...part.source,
+              text: {
+                ...part.source.text,
+                start: 0,
+                end: 0,
+              },
+            },
+          }))
+        : value
+    return Bun.deepEquals(normalize(before), normalize(after))
+  }
+
+  function press(ctx: ReturnType<typeof createHandler>, name: string, options?: Parameters<typeof createEvent>[1]) {
+    return ctx.handler.handleKey(createEvent(name, options).event)
+  }
+
+  test("dot repeats x", () => {
+    const ctx = createHandler("abcd")
+    ctx.textarea.cursorOffset = 1
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("acd")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("ad")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+  })
+
+  test("dot repeats dd", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 0
+
+    press(ctx, "d")
+    press(ctx, "d")
+    expect(ctx.textarea.plainText).toBe("two\nthree")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("three")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("dot repeats d% from the current cursor", () => {
+    const ctx = createHandler("(a) (b)")
+
+    press(ctx, "d")
+    press(ctx, "%")
+    expect(ctx.textarea.plainText).toBe(" (b)")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("dot repeat of c% no-ops when the repeated motion fails", () => {
+    const ctx = createHandler("(a) z")
+
+    press(ctx, "c")
+    press(ctx, "%")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("X z")
+
+    press(ctx, "w")
+    expect(ctx.textarea.cursorOffset).toBe(2)
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("X z")
+    expect(ctx.textarea.cursorOffset).toBe(2)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("dot repeats d} from the current cursor", () => {
+    const ctx = createHandler("one\ntwo\n\nthree\nfour\n\nfive")
+
+    press(ctx, "d")
+    press(ctx, "}")
+    expect(ctx.textarea.plainText).toBe("\nthree\nfour\n\nfive")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("\nfive")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("dot repeats cw inserted text", () => {
+    const ctx = createHandler("hello world")
+
+    press(ctx, "c")
+    press(ctx, "w")
+    ctx.textarea.insertText("hi")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("hi world")
+
+    ctx.textarea.cursorOffset = 3
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("hi hi")
+  })
+
+  test("dot repeats cw even when inserted text matches deleted word", () => {
+    const ctx = createHandler("foo bar")
+
+    press(ctx, "c")
+    press(ctx, "w")
+    ctx.textarea.insertText("foo")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("foo bar")
+
+    press(ctx, "w")
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("foo foo")
+  })
+
+  test("dot repeats cw with no inserted text", () => {
+    const ctx = createHandler("one two three")
+
+    press(ctx, "c")
+    press(ctx, "w")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe(" two three")
+
+    press(ctx, "w")
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("  three")
+  })
+
+  test("dot repeat of cw no-ops when the repeated motion fails", () => {
+    const ctx = createHandler("one")
+
+    press(ctx, "c")
+    press(ctx, "w")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("X")
+
+    ctx.textarea.cursorOffset = ctx.textarea.plainText.length
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("X")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("dot repeat of cb no-ops when the repeated motion fails", () => {
+    const ctx = createHandler("one two")
+    ctx.textarea.cursorOffset = 3
+
+    press(ctx, "c")
+    press(ctx, "b")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("X two")
+
+    ctx.textarea.cursorOffset = 0
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("X two")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("dot repeats insert text", () => {
+    const ctx = createHandler("ab cd")
+    ctx.textarea.cursorOffset = 1
+
+    press(ctx, "i")
+    ctx.textarea.insertText("XY")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("aXYb cd")
+
+    ctx.textarea.cursorOffset = 5
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aXYb XYcd")
+  })
+
+  test("dot repeats insert through textarea APIs so prompt part offsets move", () => {
+    const part: RepeatFilePart = {
+      type: "file",
+      filename: "a.txt",
+      source: { type: "file", path: "a.txt", text: { start: 3, end: 6, value: "[A]" } },
+    }
+    const ctx = createHandler("ab [A]", { data: [part], snapshotDataEqual: repeatFilePartDataEqual })
+    const insertText = ctx.textarea.insertText.bind(ctx.textarea)
+    ctx.textarea.insertText = (...args: Parameters<TextareaRenderable["insertText"]>) => {
+      const text = args[0]
+      const offset = ctx.textarea.cursorOffset
+      const result = insertText(...args)
+      ctx.setMeta(
+        (ctx.meta() as RepeatFilePart[]).map((part) =>
+          offset <= part.source.text.start
+            ? {
+                ...part,
+                source: {
+                  ...part.source,
+                  text: {
+                    ...part.source.text,
+                    start: part.source.text.start + text.length,
+                    end: part.source.text.end + text.length,
+                  },
+                },
+              }
+            : part,
+        ),
+      )
+      return result
+    }
+
+    press(ctx, "i")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("Xab [A]")
+    expect(ctx.meta()).toEqual([
+      {
+        type: "file",
+        filename: "a.txt",
+        source: { type: "file", path: "a.txt", text: { start: 4, end: 7, value: "[A]" } },
+      },
+    ])
+
+    ctx.textarea.cursorOffset = 2
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("XaXb [A]")
+    expect(ctx.meta()).toEqual([
+      {
+        type: "file",
+        filename: "a.txt",
+        source: { type: "file", path: "a.txt", text: { start: 5, end: 8, value: "[A]" } },
+      },
+    ])
+  })
+
+  test("dot repeats insert at cursor when inserted text matches neighbor", () => {
+    const ctx = createHandler("aba")
+
+    press(ctx, "0")
+    press(ctx, "i")
+    ctx.textarea.insertText("a")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("aaba")
+
+    press(ctx, "l")
+    press(ctx, "l")
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aaaba")
+  })
+
+  test("dot repeats insert backspace replacement", () => {
+    const ctx = createHandler("ab cd")
+    ctx.textarea.cursorOffset = 1
+
+    press(ctx, "i")
+    ctx.textarea.deleteRange(0, 1, 0, 2)
+    ctx.textarea.insertText("Xb")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("aXb cd")
+
+    ctx.textarea.cursorOffset = 5
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aXb cXb")
+    expect(ctx.textarea.cursorOffset).toBe(6)
+  })
+
+  test("data-changing insert clears dot repeat", () => {
+    const ctx = createHandler("abcd", { data: [{ kind: "file", name: "a" }] })
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("bcd")
+
+    press(ctx, "i")
+    ctx.textarea.insertText("X")
+    ctx.setMeta([
+      { kind: "file", name: "a" },
+      { kind: "file", name: "b" },
+    ])
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("Xbcd")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("Xbcd")
+    expect(ctx.meta()).toEqual([
+      { kind: "file", name: "a" },
+      { kind: "file", name: "b" },
+    ])
+  })
+
+  test("offset-only prompt part data changes preserve dot repeat", () => {
+    const part: RepeatFilePart = {
+      type: "file",
+      filename: "a.txt",
+      source: { type: "file", path: "a.txt", text: { start: 5, end: 8, value: "[A]" } },
+    }
+    const ctx = createHandler("xabc [A]", { data: [part], snapshotDataEqual: repeatFilePartDataEqual })
+    const deleteRange = ctx.textarea.deleteRange.bind(ctx.textarea)
+    ctx.textarea.deleteRange = (...args: Parameters<TextareaRenderable["deleteRange"]>) => {
+      const result = deleteRange(...args)
+      ctx.setMeta(
+        (ctx.meta() as RepeatFilePart[]).map((part) => ({
+          ...part,
+          source: {
+            ...part.source,
+            text: {
+              ...part.source.text,
+              start: part.source.text.start - 1,
+              end: part.source.text.end - 1,
+            },
+          },
+        })),
+      )
+      return result
+    }
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("abc [A]")
+    expect(ctx.meta()).toEqual([
+      {
+        type: "file",
+        filename: "a.txt",
+        source: { type: "file", path: "a.txt", text: { start: 4, end: 7, value: "[A]" } },
+      },
+    ])
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("bc [A]")
+    expect(ctx.meta()).toEqual([
+      {
+        type: "file",
+        filename: "a.txt",
+        source: { type: "file", path: "a.txt", text: { start: 3, end: 6, value: "[A]" } },
+      },
+    ])
+  })
+
+  test("semantic prompt part data changes clear dot repeat", () => {
+    const ctx = createHandler("abcd", {
+      data: [
+        {
+          type: "file",
+          filename: "a.txt",
+          source: { type: "file", path: "a.txt", text: { start: 0, end: 3, value: "[A]" } },
+        } satisfies RepeatFilePart,
+      ],
+      snapshotDataEqual: repeatFilePartDataEqual,
+    })
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("bcd")
+
+    press(ctx, "i")
+    ctx.textarea.insertText("X")
+    ctx.setMeta([
+      {
+        type: "file",
+        filename: "b.txt",
+        source: { type: "file", path: "b.txt", text: { start: 1, end: 4, value: "[B]" } },
+      } satisfies RepeatFilePart,
+    ])
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("Xbcd")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("Xbcd")
+  })
+
+  test("data-changing replay clears dot repeat", () => {
+    const ctx = createHandler("abcd", { data: [] })
+    const deleteRange = ctx.textarea.deleteRange.bind(ctx.textarea)
+    let updateMeta = false
+    ctx.textarea.deleteRange = (...args: Parameters<TextareaRenderable["deleteRange"]>) => {
+      const result = deleteRange(...args)
+      if (updateMeta) ctx.setMeta([{ kind: "file", name: "a" }])
+      return result
+    }
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("bcd")
+
+    updateMeta = true
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("cd")
+    expect(ctx.meta()).toEqual([{ kind: "file", name: "a" }])
+
+    updateMeta = false
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("cd")
+  })
+
+  test("reset history during active insert restores textarea recorder", () => {
+    const ctx = createHandler("abcd")
+    const insertText = ctx.textarea.insertText
+
+    press(ctx, "i")
+    expect(ctx.textarea.insertText).not.toBe(insertText)
+
+    ctx.state.resetHistory()
+    expect(ctx.textarea.insertText).toBe(insertText)
+  })
+
+  test("dot repeats complex insert sessions from the current text", () => {
+    const ctx = createHandler("abcd")
+    ctx.textarea.cursorOffset = 1
+
+    press(ctx, "i")
+    ctx.textarea.insertText("X")
+    ctx.textarea.cursorOffset = 3
+    ctx.textarea.insertText("Y")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("aXbYcd")
+
+    ctx.textarea.setText("pqrs")
+    ctx.textarea.cursorOffset = 1
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("pXqYrs")
+    expect(ctx.textarea.cursorOffset).toBe(3)
+  })
+
+  test("empty insert clears dot repeat", () => {
+    const ctx = createHandler("abcd")
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("bcd")
+
+    press(ctx, "i")
+    press(ctx, "escape")
+    press(ctx, ".")
+
+    expect(ctx.textarea.plainText).toBe("bcd")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("dot repeats blank open line", () => {
+    const ctx = createHandler("abc")
+    ctx.textarea.cursorOffset = 1
+
+    press(ctx, "o")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("abc\n")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("abc\n\n")
+  })
+
+  test("dot repeats append text", () => {
+    const ctx = createHandler("abc")
+
+    press(ctx, "a")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("aXbc")
+
+    ctx.textarea.cursorOffset = 2
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aXbXc")
+  })
+
+  test("dot repeats append at line end", () => {
+    const ctx = createHandler("one\ntwo")
+
+    press(ctx, "A")
+    ctx.textarea.insertText("!")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("one!\ntwo")
+
+    ctx.textarea.cursorOffset = 5
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("one!\ntwo!")
+  })
+
+  test("dot repeats insert at line start", () => {
+    const ctx = createHandler("  one\n  two")
+    ctx.textarea.cursorOffset = 4
+
+    press(ctx, "I")
+    ctx.textarea.insertText(">")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("  >one\n  two")
+
+    ctx.textarea.cursorOffset = rowColToOffset(ctx.textarea.plainText, 1, 4)
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("  >one\n  >two")
+  })
+
+  test("dot repeats substitute line", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    press(ctx, "S")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("one\nX\nthree")
+
+    ctx.textarea.cursorOffset = rowColToOffset(ctx.textarea.plainText, 2, 1)
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("one\nX\nX")
+  })
+
+  test("dot repeats substitute to line end", () => {
+    const ctx = createHandler("abc def\nghi jkl")
+    ctx.textarea.cursorOffset = 4
+
+    press(ctx, "C")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("abc X\nghi jkl")
+
+    ctx.textarea.cursorOffset = rowColToOffset(ctx.textarea.plainText, 1, 4)
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("abc X\nghi X")
+  })
+
+  test("dot repeats paste", () => {
+    const ctx = createHandler("abc")
+    ctx.state.setRegister({ text: "X", linewise: false })
+
+    press(ctx, "p")
+    expect(ctx.textarea.plainText).toBe("aXbc")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aXXbc")
+  })
+
+  test("dot repeats paste with the original register", () => {
+    const ctx = createHandler("abc")
+    ctx.state.setRegister({ text: "X", linewise: false })
+
+    press(ctx, "p")
+    expect(ctx.textarea.plainText).toBe("aXbc")
+
+    ctx.state.setRegister({ text: "Y", linewise: false })
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aXXbc")
+  })
+
+  test("dot repeats join", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+
+    press(ctx, "J")
+    expect(ctx.textarea.plainText).toBe("one two\nthree")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("one two three")
+  })
+
+  test("dot repeats toggle case", () => {
+    const ctx = createHandler("ab")
+
+    press(ctx, "~")
+    expect(ctx.textarea.plainText).toBe("Ab")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("AB")
+  })
+
+  test("visual change does not replace dot repeat", () => {
+    const ctx = createHandler("abcdef")
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("bcdef")
+
+    ctx.textarea.cursorOffset = 1
+    press(ctx, "v")
+    press(ctx, "l")
+    press(ctx, "c")
+    ctx.textarea.insertText("Q")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("bQef")
+
+    ctx.textarea.cursorOffset = 0
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("Qef")
+  })
+
+  test("dot repeats replace character", () => {
+    const ctx = createHandler("abcd")
+    ctx.textarea.cursorOffset = 1
+
+    press(ctx, "r")
+    press(ctx, "X")
+    expect(ctx.textarea.plainText).toBe("aXcd")
+
+    ctx.textarea.cursorOffset = 2
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aXXd")
+  })
+
+  test("dot repeats replace even when first replacement is same character", () => {
+    const ctx = createHandler("ab")
+
+    press(ctx, "0")
+    press(ctx, "r")
+    press(ctx, "a")
+    expect(ctx.textarea.plainText).toBe("ab")
+
+    press(ctx, "l")
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aa")
+  })
+
+  test("dot repeats replace mode even when first replacement is same character", () => {
+    const ctx = createHandler("ab")
+
+    press(ctx, "0")
+    press(ctx, "R", { shift: true })
+    press(ctx, "a")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("ab")
+
+    press(ctx, "l")
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("aa")
+  })
+
+  test("dot repeats replace mode changed text", () => {
+    const ctx = createHandler("ab")
+
+    press(ctx, "0")
+    press(ctx, "R", { shift: true })
+    press(ctx, "X", { shift: true })
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("Xb")
+
+    press(ctx, "l")
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("XX")
+  })
+
+  test("yank and motion do not replace dot repeat", () => {
+    const ctx = createHandler("abcd ef")
+
+    press(ctx, "x")
+    expect(ctx.textarea.plainText).toBe("bcd ef")
+    press(ctx, "w")
+    press(ctx, "y")
+    press(ctx, "w")
+    ctx.textarea.cursorOffset = 0
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("cd ef")
+  })
+
+  test("dot with no repeat is consumed", () => {
+    const ctx = createHandler("abc")
+    const dot = createEvent(".")
+
+    expect(ctx.handler.handleKey(dot.event)).toBe(true)
+    expect(dot.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("abc")
+  })
+
+  test("u after dot undoes only the repeated change", () => {
+    const ctx = createHandler("abcd")
+
+    press(ctx, "x")
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("cd")
+
+    press(ctx, "u")
+    expect(ctx.textarea.plainText).toBe("bcd")
+  })
+})
+
 describe("vim undo redo", () => {
   test("u undoes and ctrl+r redoes normal mode edits", () => {
     const ctx = createHandler("abcd")
@@ -4517,11 +5211,17 @@ describe("vim undo redo", () => {
 
     ctx.handler.handleKey(createEvent("i").event)
     ctx.textarea.insertText("x")
-    ctx.setMeta([{ kind: "file", name: "a" }, { kind: "file", name: "b" }])
+    ctx.setMeta([
+      { kind: "file", name: "a" },
+      { kind: "file", name: "b" },
+    ])
     ctx.handler.handleKey(createEvent("escape").event)
 
     expect(ctx.textarea.plainText).toBe("abcx")
-    expect(ctx.meta()).toEqual([{ kind: "file", name: "a" }, { kind: "file", name: "b" }])
+    expect(ctx.meta()).toEqual([
+      { kind: "file", name: "a" },
+      { kind: "file", name: "b" },
+    ])
 
     ctx.handler.handleKey(createEvent("u").event)
     expect(ctx.textarea.plainText).toBe("abc")
@@ -4529,7 +5229,10 @@ describe("vim undo redo", () => {
 
     ctx.handler.handleKey(createEvent("r", { ctrl: true }).event)
     expect(ctx.textarea.plainText).toBe("abcx")
-    expect(ctx.meta()).toEqual([{ kind: "file", name: "a" }, { kind: "file", name: "b" }])
+    expect(ctx.meta()).toEqual([
+      { kind: "file", name: "a" },
+      { kind: "file", name: "b" },
+    ])
   })
 
   test("empty insert sessions do not create undo entries", () => {
@@ -5944,15 +6647,22 @@ describe("copy mode cursor state", () => {
     const textarea = createTextarea("")
     const [enabled] = createSignal(true)
     const [mode, setMode] = createSignal<"normal" | "insert" | "replace" | "visual" | "visual-line" | "copy">("copy")
-    const [pending, setPending] = createSignal<"" | "c" | "d" | "g" | "z" | "f" | "F" | "t" | "T" | "y" | "w" | "r" | "vr">("")
+    const [pending, setPending] = createSignal<
+      "" | "c" | "d" | "g" | "z" | "f" | "F" | "t" | "T" | "y" | "w" | "r" | "vr"
+    >("")
     const [lastFind, setLastFind] = createSignal<{ char: string; forward: boolean; till: boolean } | null>(null)
     const [register, setRegister] = createSignal<{ text: string; linewise: boolean } | null>(null)
     const [anchor, setAnchor] = createSignal<number | null>(null)
     const [replace, setReplace] = createSignal<number | null>(null)
     const [typed, setTyped] = createSignal(false)
-    const [undos, setUndos] = createSignal<Array<{ before: { text: string; cursor: number }; after: { text: string; cursor: number } }>>([])
+    const [undos, setUndos] = createSignal<
+      Array<{ before: { text: string; cursor: number }; after: { text: string; cursor: number } }>
+    >([])
     const [redos, setRedos] = createSignal<Array<{ text: string; cursor: number }>>([])
     const [editState, setEditState] = createSignal<{ text: string; cursor: number } | null>(null)
+    const [repeat, setRepeat] = createSignal<{ run: () => boolean } | null>(null)
+    const [replaying, setReplaying] = createSignal(false)
+    const cancelEditCallbacks = new Set<() => void>()
 
     let idx = opts?.idx ?? 0
     let col = opts?.col ?? lines[0]!.min
@@ -5994,6 +6704,11 @@ describe("copy mode cursor state", () => {
       setMode(next)
     }
 
+    function cancelOpenEdit() {
+      cancelEditCallbacks.forEach((callback) => callback())
+      setEditState(null)
+    }
+
     const state: ReturnType<typeof createVimState> = {
       mode,
       setMode: changeMode,
@@ -6022,8 +6737,18 @@ describe("copy mode cursor state", () => {
         setRedos([])
       },
       cancelEdit() {
-        setEditState(null)
+        cancelOpenEdit()
       },
+      onCancelEdit(callback) {
+        cancelEditCallbacks.add(callback)
+        return () => cancelEditCallbacks.delete(callback)
+      },
+      repeat,
+      setRepeat(next) {
+        setRepeat(next)
+      },
+      replaying,
+      setReplaying,
       push(before, after) {
         setEditState(null)
         if (before.text === after.text && before.cursor === after.cursor) return
@@ -6047,9 +6772,10 @@ describe("copy mode cursor state", () => {
         return item
       },
       resetHistory() {
+        cancelOpenEdit()
         setUndos([])
         setRedos([])
-        setEditState(null)
+        setRepeat(null)
       },
       canUndo: () => undos().length > 0,
       canRedo: () => redos().length > 0,
@@ -6058,9 +6784,10 @@ describe("copy mode cursor state", () => {
         setAnchor(null)
         setReplace(null)
         setTyped(false)
+        cancelOpenEdit()
         setUndos([])
         setRedos([])
-        setEditState(null)
+        setRepeat(null)
         setMode("insert")
       },
       isInsert: () => mode() === "insert",


### PR DESCRIPTION
came out pretty hefty. it's an attempt, and feedback very welcome. really hoping to get this feature in. :eyes: 

excluded 2 features to keep the scope from being too big:
- visual mode dot repeat
- count with dot repeat (`2.`)