### PR TITLE
fix: restore copy mode ctrl-y

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -1129,7 +1129,7 @@ export function createVimHandler(input: {
       return true
     }
 
-    if (key === "y") {
+    if (key === "y" && !event.shift && !hasModifier(event)) {
       if (input.copyIsVisual?.()) {
         input.copyYank?.()
         input.copyExitPreserveScroll?.()

--- a/packages/opencode/test/cli/cmd/tui/keymap.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/keymap.test.ts
@@ -43,4 +43,24 @@ describe("opencode keymap", () => {
     expect(calls).toEqual(["toggle-copy"])
     expect(testKeymap.keymap.getPendingSequence()).toEqual([])
   })
+
+  test("copy mode ctrl scroll bindings can claim keys before global bindings", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+    const keys = ["ctrl+d", "ctrl+u", "ctrl+f", "ctrl+b", "ctrl+e", "ctrl+y"]
+
+    testKeymap.keymap.registerLayer({
+      bindings: keys.map((key) => ({ key, cmd: () => void calls.push(`global:${key}`) })),
+    })
+    testKeymap.keymap.registerLayer({
+      priority: 100,
+      bindings: keys.map((key) => ({ key, cmd: () => void calls.push(`copy:${key}`) })),
+    })
+
+    for (const key of ["d", "u", "f", "b", "e", "y"]) {
+      testKeymap.host.press(key, { ctrl: true })
+    }
+
+    expect(calls).toEqual(keys.map((key) => `copy:${key}`))
+  })
 })

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -5882,13 +5882,23 @@ describe("copy mode", () => {
     expect(ctx.copyCol()).toBe(6)
   })
 
-  test("copy mode ctrl scroll still scrolls", () => {
+  test("copy mode ctrl scroll keys still scroll", () => {
     const ctx = createHandler("abc", { mode: "copy" })
+    const keys: Array<[string, VimScroll]> = [
+      ["e", "line-down"],
+      ["y", "line-up"],
+      ["d", "half-down"],
+      ["u", "half-up"],
+      ["f", "page-down"],
+      ["b", "page-up"],
+    ]
 
-    const evt = createEvent("d", { ctrl: true })
-    expect(ctx.handler.handleKey(evt.event)).toBe(true)
-    expect(evt.prevented()).toBe(true)
-    expect(ctx.scrollCalls.at(-1)).toBe("half-down")
+    for (const [key, action] of keys) {
+      const evt = createEvent(key, { ctrl: true })
+      expect(ctx.handler.handleKey(evt.event)).toBe(true)
+      expect(evt.prevented()).toBe(true)
+      expect(ctx.scrollCalls.at(-1)).toBe(action)
+    }
   })
 
   test("copy mode ignores printable keys without side effects", () => {


### PR DESCRIPTION
closes #121 