### PR TITLE
fix: window navigation between copy when ctrl + w + w/j/k all held down at once

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1155,7 +1155,7 @@ export function Prompt(props: PromptProps) {
       !!props.copy,
     bindings: [
       {
-        key: `<${VIM_WINDOW_TOKEN}>k`,
+        key: `<${VIM_WINDOW_TOKEN}>k,<${VIM_WINDOW_TOKEN}>ctrl+k`,
         desc: "Enter copy mode",
         group: "Session",
         cmd: () => {
@@ -1166,7 +1166,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        key: `<${VIM_WINDOW_TOKEN}>w,<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>`,
+        key: `<${VIM_WINDOW_TOKEN}>w,<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>,<${VIM_WINDOW_TOKEN}>ctrl+w`,
         desc: "Toggle copy mode",
         group: "Session",
         cmd: () => {
@@ -1182,7 +1182,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        key: `<${VIM_WINDOW_TOKEN}>j`,
+        key: `<${VIM_WINDOW_TOKEN}>j,<${VIM_WINDOW_TOKEN}>ctrl+j`,
         desc: "Exit copy mode",
         group: "Session",
         cmd: () => {

--- a/packages/opencode/test/cli/cmd/tui/keymap.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/keymap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createTestKeymap } from "@opentui/keymap/testing"
+import * as addons from "@opentui/keymap/addons/opentui"
 import { VIM_WINDOW_TOKEN } from "../../../../src/cli/cmd/tui/keymap"
 
 describe("opencode keymap", () => {
@@ -35,6 +36,52 @@ describe("opencode keymap", () => {
     testKeymap.keymap.registerLayer({
       priority: 100,
       bindings: [{ key: `<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>`, cmd: () => void calls.push("toggle-copy") }],
+    })
+
+    testKeymap.host.press("w", { ctrl: true })
+    testKeymap.host.press("w", { ctrl: true })
+
+    expect(calls).toEqual(["toggle-copy"])
+    expect(testKeymap.keymap.getPendingSequence()).toEqual([])
+  })
+
+  test("vim window token supports holding ctrl for j/k navigation bindings", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+
+    addons.registerCommaBindings(testKeymap.keymap)
+    testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
+    testKeymap.keymap.registerLayer({
+      priority: 100,
+      bindings: [
+        { key: `<${VIM_WINDOW_TOKEN}>j,<${VIM_WINDOW_TOKEN}>ctrl+j`, cmd: () => void calls.push("down") },
+        { key: `<${VIM_WINDOW_TOKEN}>k,<${VIM_WINDOW_TOKEN}>ctrl+k`, cmd: () => void calls.push("up") },
+      ],
+    })
+
+    testKeymap.host.press("w", { ctrl: true })
+    testKeymap.host.press("j", { ctrl: true })
+    testKeymap.host.press("w", { ctrl: true })
+    testKeymap.host.press("k", { ctrl: true })
+
+    expect(calls).toEqual(["down", "up"])
+    expect(testKeymap.keymap.getPendingSequence()).toEqual([])
+  })
+
+  test("vim window token supports comma-separated held ctrl+w binding", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+
+    addons.registerCommaBindings(testKeymap.keymap)
+    testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
+    testKeymap.keymap.registerLayer({
+      priority: 100,
+      bindings: [
+        {
+          key: `<${VIM_WINDOW_TOKEN}>w,<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>,<${VIM_WINDOW_TOKEN}>ctrl+w`,
+          cmd: () => void calls.push("toggle-copy"),
+        },
+      ],
     })
 
     testKeymap.host.press("w", { ctrl: true })

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -1671,6 +1671,32 @@ describe("vim motion handler", () => {
     expect(ctx.navigateCalls).toEqual(["up"])
   })
 
+  test("ctrl+w ctrl+k navigates to copy mode (ctrl held throughout)", () => {
+    const ctx = createHandler("abc")
+
+    expect(ctx.handler.handleKey(createEvent("w", { ctrl: true }).event)).toBe(true)
+    expect(ctx.state.pending()).toBe("w")
+
+    const k = createEvent("k", { ctrl: true })
+    expect(ctx.handler.handleKey(k.event)).toBe(true)
+    expect(k.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.navigateCalls).toEqual(["up"])
+  })
+
+  test("ctrl+w ctrl+j navigates down (ctrl held throughout)", () => {
+    const ctx = createHandler("abc")
+
+    expect(ctx.handler.handleKey(createEvent("w", { ctrl: true }).event)).toBe(true)
+    expect(ctx.state.pending()).toBe("w")
+
+    const j = createEvent("j", { ctrl: true })
+    expect(ctx.handler.handleKey(j.event)).toBe(true)
+    expect(j.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.navigateCalls).toEqual(["down"])
+  })
+
   test("ctrl+w invalid key clears pending in normal mode", () => {
     const ctx = createHandler("abc")
 
@@ -5931,6 +5957,29 @@ describe("copy mode", () => {
 
     ctx.handler.handleKey(createEvent("w", { ctrl: true }).event)
     ctx.handler.handleKey(createEvent("w").event)
+
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.copyExitArgs).toEqual([false])
+  })
+
+  test("ctrl+w ctrl+j exits copy mode (ctrl held throughout)", () => {
+    const ctx = createHandler("abc", { mode: "copy" })
+
+    expect(ctx.handler.handleKey(createEvent("w", { ctrl: true }).event)).toBe(true)
+    expect(ctx.state.pending()).toBe("w")
+
+    const j = createEvent("j", { ctrl: true })
+    expect(ctx.handler.handleKey(j.event)).toBe(true)
+    expect(j.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.copyExitArgs).toEqual([false])
+  })
+
+  test("ctrl+w ctrl+w exits copy mode (ctrl held throughout)", () => {
+    const ctx = createHandler("abc", { mode: "copy" })
+
+    ctx.handler.handleKey(createEvent("w", { ctrl: true }).event)
+    ctx.handler.handleKey(createEvent("w", { ctrl: true }).event)
 
     expect(ctx.state.mode()).toBe("normal")
     expect(ctx.copyExitArgs).toEqual([false])


### PR DESCRIPTION
Adds to the window navigation so that when ctrl + w + w/j/k are all 3 held down at the same time it will navigate. It still works as before also when a user does  ctrl + w then releases that then hits w/j/k to navigate.

I added this because I am used to holding all 3 keys down at the same time in vim/neovim for the window navigation