### PR TITLE
fix: normalize find target keys

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -134,13 +134,15 @@ export function createVimHandler(input: {
   }
 
   function isPrintable(event: VimEvent) {
-    return !!event.name && (event.name.length === 1 || event.name === "space")
+    const key = normalizedKeyName(event)
+    return key.length === 1 || key === "space"
   }
 
   function value(event: VimEvent) {
-    if (event.name === "space") return " "
-    if (event.shift && event.name?.length === 1 && /[a-z]/.test(event.name)) return event.name.toUpperCase()
-    return event.name ?? ""
+    const key = normalizedKeyName(event)
+    if (key === "space") return " "
+    if (event.shift && key.length === 1 && /[a-z]/.test(key)) return key.toUpperCase()
+    return key
   }
 
   function replaceValue(event: VimEvent, visual = false) {

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -3017,6 +3017,51 @@ describe("vim motion handler", () => {
     expect(ctx.jumpCalls).toEqual([])
   })
 
+  test("pending find normalizes slash target", () => {
+    const ctx = createHandler("ab/cd")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("f").event)
+    const slash = createEvent("slash")
+    expect(ctx.handler.handleKey(slash.event)).toBe(true)
+    expect(slash.prevented()).toBe(true)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+    expect(ctx.state.lastFind()).toEqual({ char: "/", forward: true, till: false })
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("df normalizes slash target", () => {
+    const ctx = createHandler("ab/cd")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("f").event)
+    const slash = createEvent("slash")
+    expect(ctx.handler.handleKey(slash.event)).toBe(true)
+    expect(slash.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("cd")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.register()).toEqual({ text: "ab/", linewise: false })
+    expect(ctx.state.lastFind()).toEqual({ char: "/", forward: true, till: false })
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("cf normalizes at target", () => {
+    const ctx = createHandler("ab@cd")
+    ctx.textarea.cursorOffset = 0
+
+    ctx.handler.handleKey(createEvent("c").event)
+    ctx.handler.handleKey(createEvent("f").event)
+    const at = createEvent("at")
+    expect(ctx.handler.handleKey(at.event)).toBe(true)
+    expect(at.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("cd")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.register()).toEqual({ text: "ab@", linewise: false })
+    expect(ctx.state.lastFind()).toEqual({ char: "@", forward: true, till: false })
+  })
+
   test("df deletes forward including found char", () => {
     const ctx = createHandler("hello world")
     ctx.textarea.cursorOffset = 0


### PR DESCRIPTION
Fixes find targets for punctuation keys reported by OpenTUI as named keys.
