### PR TITLE
fix: skip OSC 52 clipboard in neovim terminal

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -36,6 +36,7 @@ const getClipboardy = lazy(async () => {
  */
 function writeOsc52(text: string): void {
   if (!process.stdout.isTTY) return
+  if (process.env["NVIM"]) return
   const base64 = Buffer.from(text).toString("base64")
   const osc52 = `\x1b]52;c;${base64}\x07`
   const passthrough = process.env["TMUX"] || process.env["STY"]


### PR DESCRIPTION
 Fixes leaked OSC 52 clipboard sequences in Neovim terminals when `vim_system_clipboard_register` is enabled. Refs #148.
