### PR TITLE
ci: update homebrew tap before npm publish

### DIFF
--- a/.github/workflows/publish-ocv.yml
+++ b/.github/workflows/publish-ocv.yml
@@ -163,17 +163,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Publish npm package
-        run: bun run packages/opencode/script/publish-ocv-npm.ts
-        env:
-          OPENCODE_VERSION: ${{ inputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Compute checksums
         id: sum
         shell: bash
@@ -247,3 +236,14 @@ jobs:
           fi
           git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" commit -m "Update ocv formula v${{ inputs.version }}"
           git push
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish npm package
+        run: bun run packages/opencode/script/publish-ocv-npm.ts
+        env:
+          OPENCODE_VERSION: ${{ inputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

This PR updates the OCV release workflow so the Homebrew tap is updated before the npm publish step runs.

## Why

The `v1.15.5-ocv.3.61` GitHub Release was created successfully, but the workflow [failed](https://github.com/leohenon/opencode-vim/actions/runs/26153297522/job/76926054511#step:11:109) during npm publishing. 

Because npm publishing happened before the Homebrew tap update, the tap update steps were skipped, leaving Homebrew stuck on `1.15.4-ocv.3.60`. (Figured this out when trying to brew upgrade for some testing)

Not exactly sure why npm is failing but this would allow brew to update at least before

Homebrew does not depend on npm, so npm publish failures should not block formula updates.

## Changes

- Move npm setup/publish to run after the Homebrew tap update.
- Keep the GitHub Release and Homebrew formula publication path independent from npm registry availability.
- Preserve npm publishing as the final step so failures are still visible in the workflow.

## Validation

- Ran `git diff --check`.
- Parsed `.github/workflows/publish-ocv.yml` with Ruby YAML loader successfully.