### PR TITLE
feat: undo cleared text from esc in type your own answer question

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -148,9 +148,6 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
           if (text) {
             setClearedText({ tab: store.tab, text })
           }
-          const inputs = [...store.custom]
-          inputs[store.tab] = ""
-          setStore("custom", inputs)
           setStore("editing", false)
         },
       },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -28,6 +28,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
   })
 
   let textarea: TextareaRenderable | undefined
+  const [clearedText, setClearedText] = createSignal<{ tab: number; text: string } | undefined>()
 
   const question = createMemo(() => questions()[store.tab])
   const confirm = createMemo(() => !single() && store.tab === questions().length)
@@ -143,6 +144,13 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         desc: "Cancel answer edit",
         group: "Question",
         cmd: () => {
+          const text = textarea?.plainText ?? ""
+          if (text) {
+            setClearedText({ tab: store.tab, text })
+          }
+          const inputs = [...store.custom]
+          inputs[store.tab] = ""
+          setStore("custom", inputs)
           setStore("editing", false)
         },
       },
@@ -267,6 +275,21 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               { key: "down", desc: "Next answer", group: "Question", cmd: () => moveTo((store.selected + 1) % total) },
               { key: "j", desc: "Next answer", group: "Question", cmd: () => moveTo((store.selected + 1) % total) },
               { key: "return", desc: "Select answer", group: "Question", cmd: () => selectOption() },
+              {
+                key: "u",
+                desc: "Undo cleared text",
+                group: "Question",
+                hidden: !clearedText() || clearedText()!.tab !== store.tab,
+                cmd: () => {
+                  const stash = clearedText()
+                  if (!stash || stash.tab !== store.tab) return
+                  const inputs = [...store.custom]
+                  inputs[stash.tab] = stash.text
+                  setStore("custom", inputs)
+                  setClearedText()
+                  setStore("editing", true)
+                },
+              },
               { key: "escape", desc: "Reject question", group: "Question", cmd: () => reject() },
               ...tuiConfig.keybinds.get("app.exit"),
             ]),


### PR DESCRIPTION
I kept hitting escape when I was typing my own answers into these because I was used to the vim mode. Adding the vim mode to that one line seemed daunting so I added u to restore the previously cleared text from hitting escape when in the mode where you can choose between the options.

<img width="848" height="407" alt="image" src="https://github.com/user-attachments/assets/d0b1432d-9c64-4ad7-83aa-7687f02d1dd1" />
