### PR TITLE
feat: add vim langmap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ Yank and delete operations sync to the system clipboard, `p` / `P` paste from it
 
 ### Vim langmap
 
-Map non-English keyboard layout characters to Vim command keys. Keys and values should be single characters:
+Map non-English keyboard layout characters to Vim command keys.
+
+> Keys and values should be single characters.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ Yank and delete operations sync to the system clipboard, `p` / `P` paste from it
 > [!NOTE]
 > Terminal/OS clipboard shortcuts don’t preserve Vim linewise register state. External clipboard text is pasted as characterwise text.
 
+### Vim langmap
+
+Map non-English keyboard layout characters to Vim command keys. Keys and values should be single characters:
+
+```json
+{
+  "vim_langmap": {
+    "р": "h",
+    "о": "j",
+    "л": "k",
+    "д": "l"
+  }
+}
+```
+
 ## Neovim integration
 
 Compatible with [`opencode.nvim`](https://github.com/nickjvandyke/opencode.nvim). Use the following server config:

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -62,7 +62,7 @@ import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
 import { useVimEnabled } from "../vim"
 import { createVimState, type VimMode, type VimRegister } from "../vim/vim-state"
-import { createVimHandler } from "../vim/vim-handler"
+import { createVimHandler, vimLangmapKeyName } from "../vim/vim-handler"
 import { clearSelection } from "../vim/vim-motions"
 import { vimScroll } from "../vim/vim-scroll"
 import { useVimIndicator } from "../vim/vim-indicator"
@@ -617,11 +617,24 @@ export function Prompt(props: PromptProps) {
     }
   }
 
-  function shouldSyncVimRegister(event: { name?: string; ctrl?: boolean; meta?: boolean; super?: boolean }) {
+  function shouldSyncVimRegister(event: {
+    name?: string
+    shift?: boolean
+    ctrl?: boolean
+    meta?: boolean
+    super?: boolean
+    sequence?: string
+    raw?: string
+  }) {
     if (!useSystemClipboardRegister() || !vimEnabled()) return false
     if (event.ctrl || event.meta || event.super) return false
     if (vimState.isInsert() || vimState.isReplace() || vimState.isCopy()) return false
-    return event.name?.toLowerCase() === "p"
+    if (["r", "vr", "f", "F", "t", "T"].includes(vimState.pending())) return false
+    const key = vimLangmapKeyName(event)
+    if (key.length !== 1) return false
+    const mapped =
+      cfg.vim_langmap?.[key] ?? (event.shift ? cfg.vim_langmap?.[key.toLowerCase()]?.toUpperCase() : undefined) ?? key
+    return mapped.toLowerCase() === "p"
   }
 
   function promptJump(action: "top" | "bottom" | "high" | "middle" | "low") {
@@ -657,6 +670,7 @@ export function Prompt(props: PromptProps) {
     textarea: () => input,
     register: () => (useSystemClipboardRegister() ? clipboardRegister : vimState.register()),
     setRegister: setVimRegister,
+    langmap: () => cfg.vim_langmap,
     submit,
     scroll(action) {
       if (action === "line-down") keymap.dispatchCommand("session.line.down")

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -82,6 +82,35 @@ export type VimCopyMove = "up" | "down" | "left" | "right"
 type VimFindOperator = "f" | "F" | "t" | "T"
 type VimTextObjectScope = "inner" | "around"
 
+type VimKeyLike = { name?: string; shift?: boolean; sequence?: string; raw?: string }
+
+export function vimLangmapKeyName(event: VimKeyLike) {
+  return vimEventText(event) ?? normalizedKeyName(event)
+}
+
+function vimEventText(event: VimKeyLike) {
+  return event.sequence?.length === 1 ? event.sequence : event.raw?.length === 1 ? event.raw : undefined
+}
+
+function normalizedKeyName(event: VimKeyLike) {
+  if (event.name === "slash") return "/"
+  if (event.name === "at") return "@"
+  if (event.name === "quote") return '"'
+  if (event.name === "apostrophe") return "'"
+  if (event.name === "backtick") return "`"
+  const text = vimEventText(event)
+  if (text && (text === "/" || text === "@" || text === '"' || text === "'" || text === "`" || "()[]{}<>".includes(text))) return text
+  if (event.shift) {
+    if (event.name === "9") return "("
+    if (event.name === "0") return ")"
+    if (event.name === "[") return "{"
+    if (event.name === "]") return "}"
+    if (event.name === ",") return "<"
+    if (event.name === ".") return ">"
+  }
+  return event.name ?? ""
+}
+
 export function createVimHandler(input: {
   enabled: Accessor<boolean>
   state: ReturnType<typeof createVimState>
@@ -121,6 +150,7 @@ export function createVimHandler(input: {
   restore?: (next: VimSnapshot) => void
   register?: () => VimRegister
   setRegister?: (register: VimRegister, notify?: boolean) => void
+  langmap?: Accessor<Record<string, string> | undefined>
 }) {
   let wantedColumn: VimWantedColumn | undefined
   let pendingOperatorFind: { operation: VimOperator; find: VimFindOperator } | undefined
@@ -128,25 +158,6 @@ export function createVimHandler(input: {
 
   function hasModifier(event: VimEvent) {
     return !!event.ctrl || !!event.meta || !!event.super
-  }
-
-  function normalizedKeyName(event: VimEvent) {
-    if (event.name === "slash") return "/"
-    if (event.name === "at") return "@"
-    if (event.name === "quote") return '"'
-    if (event.name === "apostrophe") return "'"
-    if (event.name === "backtick") return "`"
-    const text = event.sequence?.length === 1 ? event.sequence : event.raw?.length === 1 ? event.raw : undefined
-    if (text && (text === "/" || text === "@" || text === '"' || text === "'" || text === "`" || "()[]{}<>".includes(text))) return text
-    if (event.shift) {
-      if (event.name === "9") return "("
-      if (event.name === "0") return ")"
-      if (event.name === "[") return "{"
-      if (event.name === "]") return "}"
-      if (event.name === ",") return "<"
-      if (event.name === ".") return ">"
-    }
-    return event.name ?? ""
   }
 
   function isPrintable(event: VimEvent) {
@@ -165,6 +176,24 @@ export function createVimHandler(input: {
     if (event.name === "return") return visual ? "\r" : "\n"
     if (isPrintable(event)) return value(event)
     return null
+  }
+
+  function langmapped(event: VimEvent) {
+    if (hasModifier(event)) return event
+    if (["r", "vr", "f", "F", "t", "T"].includes(input.state.pending())) return event
+    const key = vimLangmapKeyName(event)
+    if (key.length !== 1) return event
+    const langmap = input.langmap?.()
+    const mapped = langmap?.[key] ?? (event.shift ? langmap?.[key.toLowerCase()]?.toUpperCase() : undefined)
+    if (!mapped || mapped.length !== 1) return event
+    return {
+      ...event,
+      name: mapped,
+      sequence: mapped,
+      raw: mapped,
+      shift: /[A-Z]/.test(mapped),
+      preventDefault: () => event.preventDefault(),
+    }
   }
 
   function isShifted(event: VimEvent, key: string) {
@@ -1676,7 +1705,8 @@ export function createVimHandler(input: {
       }
 
       if (input.state.isCopy()) {
-        return copy(event, normalizedKeyName(event))
+        const mapped = langmapped(event)
+        return copy(mapped, normalizedKeyName(mapped))
       }
 
       if (input.state.isInsert()) {
@@ -1689,8 +1719,9 @@ export function createVimHandler(input: {
         return true
       }
 
-      const key = normalizedKeyName(event)
-      const result = dispatch(event, key)
+      const mapped = langmapped(event)
+      const key = normalizedKeyName(mapped)
+      const result = dispatch(mapped, key)
 
       if (result && input.state.isVisual()) {
         const a = input.state.anchor()

--- a/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
@@ -2,7 +2,7 @@ import path from "path"
 import { type ParseError as JsoncParseError, applyEdits, modify, parse as parseJsonc } from "jsonc-parser"
 import { unique } from "remeda"
 import { Option, Schema } from "effect"
-import { DiffStyle, ScrollAcceleration, ScrollSpeed } from "./tui-schema"
+import { DiffStyle, ScrollAcceleration, ScrollSpeed, VimLangmap } from "./tui-schema"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
 import { Filesystem } from "@/util/filesystem"
@@ -15,7 +15,7 @@ const TUI_SCHEMA_URL = "https://opencode.ai/tui.json"
 
 const decodeTheme = Schema.decodeUnknownOption(Schema.String)
 const decodeRecord = Schema.decodeUnknownOption(Schema.Record(Schema.String, Schema.Unknown))
-const decodeLangmap = Schema.decodeUnknownOption(Schema.Record(Schema.String, Schema.String))
+const decodeLangmap = Schema.decodeUnknownOption(VimLangmap)
 const decodeScrollSpeed = Schema.decodeUnknownOption(ScrollSpeed)
 const decodeScrollAcceleration = Schema.decodeUnknownOption(ScrollAcceleration)
 const decodeDiffStyle = Schema.decodeUnknownOption(DiffStyle)

--- a/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
@@ -15,6 +15,7 @@ const TUI_SCHEMA_URL = "https://opencode.ai/tui.json"
 
 const decodeTheme = Schema.decodeUnknownOption(Schema.String)
 const decodeRecord = Schema.decodeUnknownOption(Schema.Record(Schema.String, Schema.Unknown))
+const decodeLangmap = Schema.decodeUnknownOption(Schema.Record(Schema.String, Schema.String))
 const decodeScrollSpeed = Schema.decodeUnknownOption(ScrollSpeed)
 const decodeScrollAcceleration = Schema.decodeUnknownOption(ScrollAcceleration)
 const decodeDiffStyle = Schema.decodeUnknownOption(DiffStyle)
@@ -88,6 +89,7 @@ function normalizeTui(data: Record<string, unknown>):
       diff_style: "auto" | "stacked" | undefined
       vim_enter_submit: boolean | undefined
       vim_system_clipboard_register: boolean | undefined
+      vim_langmap: Record<string, string> | undefined
     }
   | undefined {
   const parsed = {
@@ -96,12 +98,14 @@ function normalizeTui(data: Record<string, unknown>):
     diff_style: Option.getOrUndefined(decodeDiffStyle(data.diff_style)),
     vim_enter_submit: Option.getOrUndefined(decodeBoolean(data.vim_enter_submit)),
     vim_system_clipboard_register: Option.getOrUndefined(decodeBoolean(data.vim_system_clipboard_register)),
+    vim_langmap: Option.getOrUndefined(decodeLangmap(data.vim_langmap)),
   }
   return parsed.scroll_speed === undefined &&
     parsed.diff_style === undefined &&
     parsed.scroll_acceleration === undefined &&
     parsed.vim_enter_submit === undefined &&
-    parsed.vim_system_clipboard_register === undefined
+    parsed.vim_system_clipboard_register === undefined &&
+    parsed.vim_langmap === undefined
     ? undefined
     : parsed
 }

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -52,6 +52,14 @@ export const DiffStyle = Schema.Literals(["auto", "stacked"]).annotate({
   description: "Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column",
 })
 
+const VimLangmapCharacter = Schema.String.check(Schema.isPattern(/^.$/u)).annotate({
+  description: "A single Vim langmap character",
+})
+
+export const VimLangmap = Schema.Record(VimLangmapCharacter, VimLangmapCharacter).annotate({
+  description: "Map keyboard-layout characters to Vim command keys in normal, visual, and copy modes",
+})
+
 export const Attention = Schema.Struct({
   enabled: Schema.optional(Schema.Boolean),
   notifications: Schema.optional(Schema.Boolean),
@@ -87,8 +95,6 @@ export const TuiInfo = Schema.Struct({
   vim_system_clipboard_register: Schema.optional(Schema.Boolean).annotate({
     description: "Use the system clipboard instead of Vim's internal register for yank and paste",
   }),
-  vim_langmap: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({
-    description: "Map keyboard-layout characters to Vim command keys in normal, visual, and copy modes",
-  }),
+  vim_langmap: Schema.optional(VimLangmap),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
 })

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -87,5 +87,8 @@ export const TuiInfo = Schema.Struct({
   vim_system_clipboard_register: Schema.optional(Schema.Boolean).annotate({
     description: "Use the system clipboard instead of Vim's internal register for yank and paste",
   }),
+  vim_langmap: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({
+    description: "Map keyboard-layout characters to Vim command keys in normal, visual, and copy modes",
+  }),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
 })

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -166,6 +166,7 @@ function createHandler(
     }
     data?: unknown
     snapshotDataEqual?: (before: unknown, after: unknown) => boolean
+    langmap?: Record<string, string>
   },
 ) {
   const textarea = createTextarea(text, { strict: options?.strict })
@@ -341,6 +342,7 @@ function createHandler(
     textarea: () => textarea,
     register: options?.register?.get,
     setRegister: options?.register?.set,
+    langmap: () => options?.langmap,
     submit: options?.submit ?? (() => {}),
     scroll(action) {
       scrollCalls.push(action)
@@ -539,6 +541,104 @@ describe("vim motion handler", () => {
 
     ctx.handler.handleKey(createEvent("k").event)
     expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("maps langmap keys in normal mode", () => {
+    const ctx = createHandler("abc\nxy", { langmap: { р: "h", о: "j", л: "k", д: "l" } })
+
+    ctx.handler.handleKey(createEvent("д").event)
+    ctx.handler.handleKey(createEvent("д").event)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+
+    ctx.handler.handleKey(createEvent("о").event)
+    expect(ctx.textarea.cursorOffset).toBe(5)
+
+    ctx.handler.handleKey(createEvent("р").event)
+    expect(ctx.textarea.cursorOffset).toBe(4)
+
+    ctx.handler.handleKey(createEvent("л").event)
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("maps langmap keys from sequence when name is unavailable", () => {
+    const ctx = createHandler("abc\nxy", { langmap: { д: "j" } })
+
+    ctx.handler.handleKey(createEvent("", { sequence: "д" }).event)
+
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("maps langmap keys in copy mode", () => {
+    const ctx = createHandler("abc", { mode: "copy", langmap: { д: "j" } })
+
+    ctx.handler.handleKey(createEvent("д").event)
+
+    expect(ctx.copyMoves).toEqual(["down"])
+  })
+
+  test("maps named printable key aliases", () => {
+    const ctx = createHandler("abc", { langmap: { "/": "x" } })
+
+    ctx.handler.handleKey(createEvent("slash").event)
+
+    expect(ctx.textarea.plainText).toBe("bc")
+  })
+
+  test("maps langmap paste after clearing invalid pending operator", () => {
+    const ctx = createHandler("abc", {
+      langmap: { з: "p" },
+      register: { get: () => ({ text: "X", linewise: false }), set: () => {} },
+    })
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("з").event)
+
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.textarea.plainText).toBe("aXbc")
+  })
+
+  test("does not map named special keys", () => {
+    const ctx = createHandler("abc", { langmap: { escape: "i" } })
+
+    expect(ctx.handler.handleKey(createEvent("escape").event)).toBe(false)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("does not map langmap keys in insert mode", () => {
+    const ctx = createHandler("abc", { mode: "insert", langmap: { д: "l" } })
+    expect(ctx.handler.handleKey(createEvent("д").event)).toBe(false)
+  })
+
+  test("prevents original event for mapped normal mode keys", () => {
+    const ctx = createHandler("abc\nxy", { langmap: { д: "j" } })
+    const event = {
+      name: "д",
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true
+      },
+    }
+
+    expect(ctx.handler.handleKey(event)).toBe(true)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test("does not map replacement characters", () => {
+    const ctx = createHandler("abc", { langmap: { д: "j" } })
+
+    ctx.handler.handleKey(createEvent("r").event)
+    ctx.handler.handleKey(createEvent("д").event)
+
+    expect(ctx.textarea.plainText).toBe("дbc")
+  })
+
+  test("does not map find target characters", () => {
+    const ctx = createHandler("abcдj", { langmap: { а: "f", д: "j" } })
+
+    ctx.handler.handleKey(createEvent("а").event)
+    ctx.handler.handleKey(createEvent("д").event)
+
+    expect(ctx.textarea.cursorOffset).toBe(3)
   })
 
   test("h clamps at line start", () => {

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -187,7 +187,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       const source = path.join(test.directory, "opencode.json")
       yield* fs.writeJson(source, {
         theme: "migrated-theme",
-        tui: { scroll_speed: 5, vim_enter_submit: true },
+        tui: { scroll_speed: 5, vim_enter_submit: true, vim_langmap: { д: "l" } },
         keybinds: { app_exit: "ctrl+q" },
       })
 
@@ -195,11 +195,13 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       expect(config.theme).toBe("migrated-theme")
       expect(config.scroll_speed).toBe(5)
       expect(config.vim_enter_submit).toBe(true)
+      expect(config.vim_langmap).toEqual({ д: "l" })
       expect(config.keybinds.get("app.exit")?.[0]?.key).toBe("ctrl+q")
       expect(JSON.parse(yield* fs.readFileString(path.join(test.directory, "tui.json")))).toMatchObject({
         theme: "migrated-theme",
         scroll_speed: 5,
         vim_enter_submit: true,
+        vim_langmap: { д: "l" },
       })
       const server = JSON.parse(yield* fs.readFileString(source))
       expect(server.theme).toBeUndefined()

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "bun:test"
 import path from "path"
 import { pathToFileURL } from "url"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Option, Schema } from "effect"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Global } from "@opencode-ai/core/global"
 import { Config } from "@/config/config"
@@ -211,6 +211,16 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       expect(yield* fs.existsSafe(path.join(test.directory, "tui.json"))).toBe(true)
     }),
   ),
+)
+
+it.instance("validates vim langmap entries are single characters", () =>
+  Effect.sync(() => {
+    const decode = Schema.decodeUnknownOption(TuiConfig.Info)
+
+    expect(Option.isSome(decode({ vim_langmap: { д: "l" } }))).toBe(true)
+    expect(Option.isNone(decode({ vim_langmap: { дд: "l" } }))).toBe(true)
+    expect(Option.isNone(decode({ vim_langmap: { д: "ll" } }))).toBe(true)
+  }),
 )
 
 it.instance("migrates project legacy tui keys even when global tui.json already exists", () =>


### PR DESCRIPTION
Closes #146 

Adds `vim_langmap` TUI config for mapping characters to vim command keys.