### PR TITLE
feat: add return to insert mode after submit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ To submit from insert mode too:
 }
 ```
 
+To always default to insert mode after a prompt submission:
+
+```json
+{
+  "vim_insert_after_submit": true
+}
+```
+
 To keep newline available:
 
 ```json

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1851,6 +1851,7 @@ export function Prompt(props: PromptProps) {
     })
     setStore("extmarkToPartIndex", new Map())
     vimState.resetHistory()
+    if (cfg.vim_insert_after_submit && vimEnabled() && !vimState.isCopy()) vimState.setMode("insert")
     props.onSubmit?.()
 
     // temporary hack to make sure the message is sent

--- a/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
@@ -88,6 +88,7 @@ function normalizeTui(data: Record<string, unknown>):
       scroll_acceleration: { enabled: boolean } | undefined
       diff_style: "auto" | "stacked" | undefined
       vim_enter_submit: boolean | undefined
+      vim_insert_after_submit: boolean | undefined
       vim_system_clipboard_register: boolean | undefined
       vim_langmap: Record<string, string> | undefined
     }
@@ -97,6 +98,7 @@ function normalizeTui(data: Record<string, unknown>):
     scroll_acceleration: Option.getOrUndefined(decodeScrollAcceleration(data.scroll_acceleration)),
     diff_style: Option.getOrUndefined(decodeDiffStyle(data.diff_style)),
     vim_enter_submit: Option.getOrUndefined(decodeBoolean(data.vim_enter_submit)),
+    vim_insert_after_submit: Option.getOrUndefined(decodeBoolean(data.vim_insert_after_submit)),
     vim_system_clipboard_register: Option.getOrUndefined(decodeBoolean(data.vim_system_clipboard_register)),
     vim_langmap: Option.getOrUndefined(decodeLangmap(data.vim_langmap)),
   }
@@ -104,6 +106,7 @@ function normalizeTui(data: Record<string, unknown>):
     parsed.diff_style === undefined &&
     parsed.scroll_acceleration === undefined &&
     parsed.vim_enter_submit === undefined &&
+    parsed.vim_insert_after_submit === undefined &&
     parsed.vim_system_clipboard_register === undefined &&
     parsed.vim_langmap === undefined
     ? undefined

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -101,6 +101,9 @@ export const TuiInfo = Schema.Struct({
   vim_enter_submit: Schema.optional(Schema.Boolean).annotate({
     description: "Submit prompt with Enter in vim insert and replace modes",
   }),
+  vim_insert_after_submit: Schema.optional(Schema.Boolean).annotate({
+    description: "Return prompt to Vim insert mode after submitting",
+  }),
   vim_system_clipboard_register: Schema.optional(Schema.Boolean).annotate({
     description: "Use the system clipboard instead of Vim's internal register for yank and paste",
   }),

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -120,13 +120,18 @@ it.instance("loads tui config with the same precedence order as server config pa
       yield* fs.writeJson(path.join(test.directory, "tui.json"), { theme: "project" })
       yield* fs.writeWithDirs(
         path.join(test.directory, ".opencode", "tui.json"),
-        JSON.stringify({ theme: "local", diff_style: "stacked", vim_enter_submit: true }, null, 2),
+        JSON.stringify(
+          { theme: "local", diff_style: "stacked", vim_enter_submit: true, vim_insert_after_submit: true },
+          null,
+          2,
+        ),
       )
 
       const config = yield* getTuiConfig(test.directory)
       expect(config.theme).toBe("local")
       expect(config.diff_style).toBe("stacked")
       expect(config.vim_enter_submit).toBe(true)
+      expect(config.vim_insert_after_submit).toBe(true)
     }),
   ),
 )
@@ -187,7 +192,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       const source = path.join(test.directory, "opencode.json")
       yield* fs.writeJson(source, {
         theme: "migrated-theme",
-        tui: { scroll_speed: 5, vim_enter_submit: true, vim_langmap: { д: "l" } },
+        tui: { scroll_speed: 5, vim_enter_submit: true, vim_insert_after_submit: true, vim_langmap: { д: "l" } },
         keybinds: { app_exit: "ctrl+q" },
       })
 
@@ -195,12 +200,14 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       expect(config.theme).toBe("migrated-theme")
       expect(config.scroll_speed).toBe(5)
       expect(config.vim_enter_submit).toBe(true)
+      expect(config.vim_insert_after_submit).toBe(true)
       expect(config.vim_langmap).toEqual({ д: "l" })
       expect(config.keybinds.get("app.exit")?.[0]?.key).toBe("ctrl+q")
       expect(JSON.parse(yield* fs.readFileString(path.join(test.directory, "tui.json")))).toMatchObject({
         theme: "migrated-theme",
         scroll_speed: 5,
         vim_enter_submit: true,
+        vim_insert_after_submit: true,
         vim_langmap: { д: "l" },
       })
       const server = JSON.parse(yield* fs.readFileString(source))
@@ -389,13 +396,14 @@ it.instance("flattens nested tui key inside tui.json", () =>
       const test = yield* TestInstance
       yield* fs.writeJson(path.join(test.directory, "tui.json"), {
         theme: "outer",
-        tui: { scroll_speed: 3, diff_style: "stacked", vim_enter_submit: true },
+        tui: { scroll_speed: 3, diff_style: "stacked", vim_enter_submit: true, vim_insert_after_submit: true },
       })
 
       const config = yield* getTuiConfig(test.directory)
       expect(config.scroll_speed).toBe(3)
       expect(config.diff_style).toBe("stacked")
       expect(config.vim_enter_submit).toBe(true)
+      expect(config.vim_insert_after_submit).toBe(true)
       expect(config.theme).toBe("outer")
     }),
   ),
@@ -408,12 +416,14 @@ it.instance("top-level keys in tui.json take precedence over nested tui key", ()
       const test = yield* TestInstance
       yield* fs.writeJson(path.join(test.directory, "tui.json"), {
         diff_style: "auto",
-        tui: { diff_style: "stacked", scroll_speed: 2 },
+        vim_insert_after_submit: false,
+        tui: { diff_style: "stacked", scroll_speed: 2, vim_insert_after_submit: true },
       })
 
       const config = yield* getTuiConfig(test.directory)
       expect(config.diff_style).toBe("auto")
       expect(config.scroll_speed).toBe(2)
+      expect(config.vim_insert_after_submit).toBe(false)
     }),
   ),
 )


### PR DESCRIPTION
Closes #166 

Adds an option to always return to insert mode after a prompt submission, regardless of which mode was active at submission. 