### PR TITLE
feat: add vim delete line-boundary motions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -18,9 +18,12 @@ import {
   findCharInLine,
   findCharTargetInLine,
   firstNonWhitespace,
+  firstNonWhitespaceOperation,
   getLineColumn,
   insertLineStart,
   joinLines,
+  lineBeginningOperation,
+  lineEndOperation,
   matchingBracketOperation,
   matchingBracketTarget,
   moveBigWordEnd,
@@ -374,6 +377,22 @@ export function createVimHandler(input: {
     }
     if ((key === "e" || isShifted(event, "e")) && !hasModifier(event)) {
       applyOperatorResult(() => wordEndOperation(isShifted(event, "e")), operation)
+      return true
+    }
+    return false
+  }
+
+  function deleteLineBoundaryMotion(event: VimEvent, key: string): boolean {
+    if (key === "$" && !hasModifier(event)) {
+      applyOperatorResult(() => lineEndOperation(input.textarea()), "d")
+      return true
+    }
+    if (key === "0" && !event.shift && !hasModifier(event)) {
+      applyOperatorResult(() => lineBeginningOperation(input.textarea()), "d")
+      return true
+    }
+    if (key === "^" && !hasModifier(event)) {
+      applyOperatorResult(() => firstNonWhitespaceOperation(input.textarea()), "d")
       return true
     }
     return false
@@ -838,6 +857,11 @@ export function createVimHandler(input: {
       }
 
       if (wordOperator(event, key, "d")) {
+        event.preventDefault()
+        return true
+      }
+
+      if (deleteLineBoundaryMotion(event, key)) {
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -249,6 +249,28 @@ function buildOperatorResult(
   return { span, register: { text: linewise ? asLinewise(slice) : slice, linewise } }
 }
 
+export function lineEndOperation(textarea: TextareaRenderable): VimOperatorResult {
+  const text = textarea.plainText
+  const start = textarea.cursorOffset
+  const end = lineEnd(text, start)
+  return buildOperatorResult(text, end > start ? { start, end } : null, null, false)
+}
+
+export function lineBeginningOperation(textarea: TextareaRenderable): VimOperatorResult {
+  const text = textarea.plainText
+  const end = textarea.cursorOffset
+  const start = lineStart(text, end)
+  return buildOperatorResult(text, start < end ? { start, end } : null, null, false)
+}
+
+export function firstNonWhitespaceOperation(textarea: TextareaRenderable): VimOperatorResult {
+  const text = textarea.plainText
+  const cursor = textarea.cursorOffset
+  const target = firstNonWhitespace(text, cursor)
+  if (target === cursor) return { span: null, register: null }
+  return buildOperatorResult(text, { start: Math.min(target, cursor), end: Math.max(target, cursor) }, null, false)
+}
+
 type NextClassification = {
   lineStartOffset: number
   onBlank: boolean

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -2455,6 +2455,82 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.cursorOffset).toBe(0)
   })
 
+  test("d$ deletes to end of line", () => {
+    const ctx = createHandler("one\ntwo three\nfour")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("d").event)
+    const motion = createEvent("$")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("one\nt\nfour")
+    expect(ctx.textarea.cursorOffset).toBe(5)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "wo three", linewise: false })
+  })
+
+  test("d$ at end of line is no-op", () => {
+    const ctx = createHandler("one\ntwo")
+    ctx.textarea.cursorOffset = 3
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("$").event)
+    expect(ctx.textarea.plainText).toBe("one\ntwo")
+    expect(ctx.textarea.cursorOffset).toBe(3)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("d0 deletes to beginning of line", () => {
+    const ctx = createHandler("one\ntwo three\nfour")
+    ctx.textarea.cursorOffset = 9
+
+    ctx.handler.handleKey(createEvent("d").event)
+    const motion = createEvent("0")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("one\nhree\nfour")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "two t", linewise: false })
+  })
+
+  test("d0 at beginning of line is no-op", () => {
+    const ctx = createHandler("one\ntwo")
+    ctx.textarea.cursorOffset = 4
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("0").event)
+    expect(ctx.textarea.plainText).toBe("one\ntwo")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("d^ deletes back to first non-whitespace", () => {
+    const ctx = createHandler("one\n  two three")
+    ctx.textarea.cursorOffset = 10
+
+    ctx.handler.handleKey(createEvent("d").event)
+    const motion = createEvent("^")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("one\n  three")
+    expect(ctx.textarea.cursorOffset).toBe(6)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "two ", linewise: false })
+  })
+
+  test("d^ deletes forward to first non-whitespace", () => {
+    const ctx = createHandler("one\n  two")
+    ctx.textarea.cursorOffset = 4
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("^").event)
+    expect(ctx.textarea.plainText).toBe("one\ntwo")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "  ", linewise: false })
+  })
+
   test("dw deletes to next word and clears pending", () => {
     const ctx = createHandler("hello world test")
     ctx.textarea.cursorOffset = 0


### PR DESCRIPTION
Part of #5 

Adds delete motions: `d$`, `d0`, `d^`

