### PR TITLE
fix: update copy mode indicators

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -2170,7 +2170,7 @@ export function Prompt(props: PromptProps) {
   }
 
   function isVisualIndicator(indicator: string) {
-    return ["-- VISUAL --", "-- VISUAL LINE --", "-- V-COPY --", "-- VL-COPY --"].includes(indicator)
+    return ["-- VISUAL --", "-- VISUAL LINE --"].includes(indicator)
   }
 
   function VimIndicator() {

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
@@ -12,9 +12,9 @@ export function useVimIndicator(input: {
     const key = input.state.pending()
     if (key && key !== "w") return (input.state.pendingDisplay() || key) + ".."
     if (input.state.isCopy()) {
-      if (input.copyVisual?.() === "char") return "-- V-COPY --"
-      if (input.copyVisual?.() === "line") return "-- VL-COPY --"
-      return "COPY"
+      if (input.copyVisual?.() === "char") return "-- VISUAL --"
+      if (input.copyVisual?.() === "line") return "-- VISUAL LINE --"
+      return "-- COPY --"
     }
     if (input.state.isInsert()) return "-- INSERT --"
     if (input.state.isReplace()) return "-- REPLACE --"

--- a/packages/opencode/test/cli/tui/vim-indicator.test.ts
+++ b/packages/opencode/test/cli/tui/vim-indicator.test.ts
@@ -50,6 +50,11 @@ describe("vim indicator", () => {
   })
 
   test("shows copy label when no key is pending", () => {
-    expect(label({ mode: "copy" })).toBe("COPY")
+    expect(label({ mode: "copy" })).toBe("-- COPY --")
+  })
+
+  test("shows visual labels in copy mode", () => {
+    expect(label({ mode: "copy", copy: "char" })).toBe("-- VISUAL --")
+    expect(label({ mode: "copy", copy: "line" })).toBe("-- VISUAL LINE --")
   })
 })


### PR DESCRIPTION
 Updates copy mode indicators for consistency:

 - `COPY` → `-- COPY --`
 - `-- V-COPY --` → `-- VISUAL --`
 - `-- VL-COPY -- `→ `-- VISUAL LINE --`
