### PR TITLE
fix(tui): allow copy mode while question dialog is open

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -63,10 +63,12 @@ import { emptyRows } from "./empty-selection"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "../../util/provider-origin"
 import {
   OPENCODE_BASE_MODE,
+  OPENCODE_COPY_MODE,
   useBindings,
   useCommandShortcut,
   useLeaderActive,
   useOpencodeKeymap,
+  useOpencodeModeStack,
   VIM_WINDOW_TOKEN,
 } from "../../keymap"
 import { useTuiConfig } from "../../config"
@@ -81,6 +83,7 @@ export type PromptProps = {
   workspaceID?: string
   visible?: boolean
   disabled?: boolean
+  copyDuringModal?: boolean
   onSubmit?: () => void
   ref?: (ref: PromptRef | undefined) => void
   hint?: JSX.Element
@@ -227,6 +230,7 @@ export function Prompt(props: PromptProps) {
   const history = usePromptHistory()
   const stash = usePromptStash()
   const keymap = useOpencodeKeymap()
+  const modeStack = useOpencodeModeStack()
   const agentShortcut = useCommandShortcut("agent.cycle")
   const paletteShortcut = useCommandShortcut("command.palette.show")
   const variantShortcut = useCommandShortcut("variant.cycle")
@@ -466,9 +470,21 @@ export function Prompt(props: PromptProps) {
     enabled: vimEnabled,
     initial: () => lastVimMode,
   })
+  let popCopyMode: (() => void) | undefined
   onCleanup(() => {
+    popCopyMode?.()
     if (vimEnabled()) lastVimMode = vimState.isCopy() ? "normal" : vimState.mode()
   })
+
+  createEffect(() => {
+    if (vimState.isCopy()) {
+      if (!popCopyMode) popCopyMode = modeStack.push(OPENCODE_COPY_MODE)
+      return
+    }
+    popCopyMode?.()
+    popCopyMode = undefined
+  })
+
   const vimIndicator = useVimIndicator({
     enabled: vimEnabled,
     active: () => store.mode === "normal",
@@ -493,21 +509,47 @@ export function Prompt(props: PromptProps) {
     return input.plainText.length > 0
   }
 
+  function enterCopyMode() {
+    if (!vimEnabled() || !props.copy) return false
+    vimState.setMode("copy")
+    props.copy.enter()
+    if (input && !input.isDestroyed && !input.focused) input.focus()
+    dialog.clear()
+    return true
+  }
+
+  function exitCopyMode(scrollToBottom?: boolean) {
+    if (!props.copy) return false
+    vimState.setMode("normal")
+    props.copy.exit(scrollToBottom)
+    dialog.clear()
+    return true
+  }
+
+  function copyEligible() {
+    return (
+      inputTarget() !== undefined &&
+      vimEnabled() &&
+      store.mode === "normal" &&
+      (!props.disabled || props.copyDuringModal)
+    )
+  }
+
   function handleNavigation(action: "up" | "down") {
     if (!props.copy) return
     if (action === "up" && !vimState.isCopy()) {
-      vimState.setMode("copy")
-      props.copy.enter()
+      enterCopyMode()
     }
     if (action === "down" && vimState.isCopy()) {
       const skipExit = vimState.skipExitOnModeChange()
       const scrollToBottom = vimState.exitScrollToBottom()
       vimState.setSkipExitOnModeChange(false)
       vimState.setExitScrollToBottom(true)
-      vimState.setMode("normal")
       if (!skipExit) {
-        props.copy.exit(scrollToBottom)
+        exitCopyMode(scrollToBottom)
+        return
       }
+      vimState.setMode("normal")
     }
   }
 
@@ -655,10 +697,11 @@ export function Prompt(props: PromptProps) {
       props.copy?.exitVisual()
     },
     copyExit(scrollToBottom) {
-      props.copy?.exit(scrollToBottom)
+      exitCopyMode(scrollToBottom)
     },
     copyExitPreserveScroll() {
       props.copy?.exitPreserveScroll()
+      vimState.setMode("normal")
     },
     copyFocusInput() {
       props.copy?.focusInput()
@@ -1053,14 +1096,10 @@ export function Prompt(props: PromptProps) {
         run: () => {
           if (!vimEnabled() || !props.copy) return
           if (vimState.isCopy()) {
-            vimState.setMode("normal")
-            props.copy.exit()
-            dialog.clear()
+            exitCopyMode()
             return
           }
-          vimState.setMode("copy")
-          props.copy.enter()
-          dialog.clear()
+          enterCopyMode()
         },
       },
       {
@@ -1154,12 +1193,7 @@ export function Prompt(props: PromptProps) {
   useBindings(() => ({
     target: inputTarget,
     priority: 100,
-    enabled:
-      inputTarget() !== undefined &&
-      !props.disabled &&
-      vimEnabled() &&
-      store.mode === "normal" &&
-      vimState.isCopy(),
+    enabled: copyEligible() && vimState.isCopy(),
     bindings: ["ctrl+d", "ctrl+u", "ctrl+f", "ctrl+b", "ctrl+e", "ctrl+y"].map((key) => ({
       key,
       desc: "Scroll copy mode",
@@ -1171,13 +1205,7 @@ export function Prompt(props: PromptProps) {
   useBindings(() => ({
     target: inputTarget,
     priority: 200,
-    enabled:
-      inputTarget() !== undefined &&
-      !props.disabled &&
-      vimEnabled() &&
-      store.mode === "normal" &&
-      vimState.isCopy() &&
-      !!props.copy?.searchActive(),
+    enabled: copyEligible() && vimState.isCopy() && !!props.copy?.searchActive(),
     bindings: [
       ...["backspace", "shift+backspace", "delete", "ctrl+h"].map((key) => ({
         key,
@@ -1208,14 +1236,7 @@ export function Prompt(props: PromptProps) {
   useBindings(() => ({
     target: inputTarget,
     priority: 200,
-    enabled:
-      inputTarget() !== undefined &&
-      !props.disabled &&
-      vimEnabled() &&
-      store.mode === "normal" &&
-      vimState.isCopy() &&
-      !props.copy?.isVisual() &&
-      !!props.copy?.searchHighlighted(),
+    enabled: copyEligible() && vimState.isCopy() && !props.copy?.isVisual() && !!props.copy?.searchHighlighted(),
     bindings: [
       {
         key: "escape",
@@ -1233,14 +1254,7 @@ export function Prompt(props: PromptProps) {
   useBindings(() => ({
     target: inputTarget,
     priority: 100,
-    enabled:
-      inputTarget() !== undefined &&
-      !props.disabled &&
-      vimEnabled() &&
-      store.mode === "normal" &&
-      !vimState.isInsert() &&
-      !vimState.isReplace() &&
-      !!props.copy,
+    enabled: copyEligible() && !vimState.isInsert() && !vimState.isReplace() && !!props.copy,
     bindings: [
       {
         key: `<${VIM_WINDOW_TOKEN}>k,<${VIM_WINDOW_TOKEN}>ctrl+k`,
@@ -1248,9 +1262,7 @@ export function Prompt(props: PromptProps) {
         group: "Session",
         cmd: () => {
           if (vimState.isCopy()) return false
-          vimState.setMode("copy")
-          props.copy?.enter()
-          dialog.clear()
+          enterCopyMode()
         },
       },
       {
@@ -1259,14 +1271,10 @@ export function Prompt(props: PromptProps) {
         group: "Session",
         cmd: () => {
           if (vimState.isCopy()) {
-            vimState.setMode("normal")
-            props.copy?.exit(false)
-            dialog.clear()
+            exitCopyMode(false)
             return
           }
-          vimState.setMode("copy")
-          props.copy?.enter()
-          dialog.clear()
+          enterCopyMode()
         },
       },
       {
@@ -1275,9 +1283,7 @@ export function Prompt(props: PromptProps) {
         group: "Session",
         cmd: () => {
           if (!vimState.isCopy()) return false
-          vimState.setMode("normal")
-          props.copy?.exit(false)
-          dialog.clear()
+          exitCopyMode(false)
         },
       },
     ],
@@ -1340,7 +1346,7 @@ export function Prompt(props: PromptProps) {
 
   createEffect(() => {
     if (!input || input.isDestroyed) return
-    if (props.visible === false || dialog.stack.length > 0) {
+    if (props.visible === false || dialog.stack.length > 0 || (props.disabled && !vimState.isCopy())) {
       if (input.focused) input.blur()
       vimState.clearPending()
       return
@@ -2227,7 +2233,7 @@ export function Prompt(props: PromptProps) {
                 setCursorVersion((value) => value + 1)
               }}
               onKeyDown={async (e: KeyEvent & { preventDefault(): void; defaultPrevented?: boolean }) => {
-                if (props.disabled) {
+                if (props.disabled && !vimState.isCopy()) {
                   e.preventDefault()
                   return
                 }

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -64,12 +64,14 @@ import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "../../util/pr
 import {
   OPENCODE_BASE_MODE,
   OPENCODE_COPY_MODE,
+  OPENCODE_COPY_MODE_ENTER_KEYS,
+  OPENCODE_COPY_MODE_EXIT_KEYS,
+  OPENCODE_COPY_MODE_TOGGLE_KEYS,
   useBindings,
   useCommandShortcut,
   useLeaderActive,
   useOpencodeKeymap,
   useOpencodeModeStack,
-  VIM_WINDOW_TOKEN,
 } from "../../keymap"
 import { useTuiConfig } from "../../config"
 import { usePromptWorkspace } from "./workspace"
@@ -1257,7 +1259,7 @@ export function Prompt(props: PromptProps) {
     enabled: copyEligible() && !vimState.isInsert() && !vimState.isReplace() && !!props.copy,
     bindings: [
       {
-        key: `<${VIM_WINDOW_TOKEN}>k,<${VIM_WINDOW_TOKEN}>ctrl+k`,
+        key: OPENCODE_COPY_MODE_ENTER_KEYS,
         desc: "Enter copy mode",
         group: "Session",
         cmd: () => {
@@ -1266,7 +1268,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        key: `<${VIM_WINDOW_TOKEN}>w,<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>,<${VIM_WINDOW_TOKEN}>ctrl+w`,
+        key: OPENCODE_COPY_MODE_TOGGLE_KEYS,
         desc: "Toggle copy mode",
         group: "Session",
         cmd: () => {
@@ -1278,7 +1280,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        key: `<${VIM_WINDOW_TOKEN}>j,<${VIM_WINDOW_TOKEN}>ctrl+j`,
+        key: OPENCODE_COPY_MODE_EXIT_KEYS,
         desc: "Exit copy mode",
         group: "Session",
         cmd: () => {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -538,7 +538,7 @@ export function Prompt(props: PromptProps) {
   function handleNavigation(action: "up" | "down") {
     if (!props.copy) return
     if (action === "up" && !vimState.isCopy()) {
-      enterCopyMode()
+      keymap.dispatchCommand("session.copy_mode")
     }
     if (action === "down" && vimState.isCopy()) {
       const skipExit = vimState.skipExitOnModeChange()
@@ -1262,7 +1262,7 @@ export function Prompt(props: PromptProps) {
         group: "Session",
         cmd: () => {
           if (vimState.isCopy()) return false
-          enterCopyMode()
+          keymap.dispatchCommand("session.copy_mode")
         },
       },
       {
@@ -1274,7 +1274,7 @@ export function Prompt(props: PromptProps) {
             exitCopyMode(false)
             return
           }
-          enterCopyMode()
+          keymap.dispatchCommand("session.copy_mode")
         },
       },
       {

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -1698,6 +1698,7 @@ export function createVimHandler(input: {
     }
     if (key === "q") {
       input.state.setMode("normal")
+      input.copyExit?.()
       event.preventDefault()
       return true
     }
@@ -1720,6 +1721,7 @@ export function createVimHandler(input: {
         return true
       }
       input.state.setMode("normal")
+      input.copyExit?.()
       event.preventDefault()
       return true
     }

--- a/packages/tui/src/keymap.tsx
+++ b/packages/tui/src/keymap.tsx
@@ -20,6 +20,7 @@ import { TuiKeybind } from "./config/keybind"
 export const LEADER_TOKEN = "leader"
 export const VIM_WINDOW_TOKEN = "vim-window"
 export const OPENCODE_BASE_MODE = "base"
+export const OPENCODE_COPY_MODE = "copy"
 export const COMMAND_PALETTE_COMMAND = "command.palette.show"
 
 const OPENCODE_MODE_KEY = "opencode.mode"

--- a/packages/tui/src/keymap.tsx
+++ b/packages/tui/src/keymap.tsx
@@ -21,6 +21,9 @@ export const LEADER_TOKEN = "leader"
 export const VIM_WINDOW_TOKEN = "vim-window"
 export const OPENCODE_BASE_MODE = "base"
 export const OPENCODE_COPY_MODE = "copy"
+export const OPENCODE_COPY_MODE_ENTER_KEYS = `<${VIM_WINDOW_TOKEN}>k,<${VIM_WINDOW_TOKEN}>ctrl+k`
+export const OPENCODE_COPY_MODE_TOGGLE_KEYS = `<${VIM_WINDOW_TOKEN}>w,<${VIM_WINDOW_TOKEN}><${VIM_WINDOW_TOKEN}>,<${VIM_WINDOW_TOKEN}>ctrl+w`
+export const OPENCODE_COPY_MODE_EXIT_KEYS = `<${VIM_WINDOW_TOKEN}>j,<${VIM_WINDOW_TOKEN}>ctrl+j`
 export const COMMAND_PALETTE_COMMAND = "command.palette.show"
 
 const OPENCODE_MODE_KEY = "opencode.mode"

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1351,13 +1351,13 @@ export function Session() {
                     name="session_prompt"
                     mode="replace"
                     session_id={route.sessionID}
-                    visible={promptMounted()}
+                    visible={visible()}
                     disabled={disabled()}
                     on_submit={toBottom}
                     ref={bind}
                   >
                     <Prompt
-                      visible={promptMounted()}
+                      visible={visible()}
                       ref={bind}
                       copy={cm.prompt}
                       copyDuringModal={questions().length > 0}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -232,6 +232,7 @@ export function Session() {
     return children().flatMap((x) => sync.data.question[x.id] ?? [])
   })
   const visible = createMemo(() => !session()?.parentID && permissions().length === 0 && questions().length === 0)
+  const promptMounted = createMemo(() => visible() || (!session()?.parentID && permissions().length === 0 && questions().length > 0))
   const disabled = createMemo(() => permissions().length > 0 || questions().length > 0)
 
   const pending = createMemo(() => {
@@ -1345,20 +1346,21 @@ export function Session() {
                 <Show when={session()?.parentID}>
                   <SubagentFooter />
                 </Show>
-                <Show when={visible()}>
+                <Show when={promptMounted()}>
                   <pluginRuntime.Slot
                     name="session_prompt"
                     mode="replace"
                     session_id={route.sessionID}
-                    visible={visible()}
+                    visible={promptMounted()}
                     disabled={disabled()}
                     on_submit={toBottom}
                     ref={bind}
                   >
                     <Prompt
-                      visible={visible()}
+                      visible={promptMounted()}
                       ref={bind}
                       copy={cm.prompt}
+                      copyDuringModal={questions().length > 0}
                       disabled={disabled()}
                       onSubmit={() => {
                         toBottom()

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -7,7 +7,7 @@ import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../ui/border"
 import { useTuiConfig } from "../../config"
-import { useBindings, useOpencodeModeStack } from "../../keymap"
+import { useBindings, useOpencodeKeymap, useOpencodeModeStack } from "../../keymap"
 
 const QUESTION_MODE = "question"
 
@@ -16,6 +16,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   const { theme } = useTheme()
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
+  const keymap = useOpencodeKeymap()
   const modeStack = useOpencodeModeStack()
 
   const questions = createMemo(() => props.request.questions)
@@ -230,6 +231,12 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         },
       ],
       bindings: [
+        ...tuiConfig.keybinds.get("session.copy_mode").map((binding) => ({
+          ...binding,
+          desc: "Enter copy mode",
+          group: "Question",
+          cmd: () => keymap.dispatchCommand("session.copy_mode"),
+        })),
         {
           key: "left",
           desc: "Previous question",

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -7,7 +7,13 @@ import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../ui/border"
 import { useTuiConfig } from "../../config"
-import { useBindings, useOpencodeKeymap, useOpencodeModeStack } from "../../keymap"
+import {
+  OPENCODE_COPY_MODE_ENTER_KEYS,
+  OPENCODE_COPY_MODE_TOGGLE_KEYS,
+  useBindings,
+  useOpencodeKeymap,
+  useOpencodeModeStack,
+} from "../../keymap"
 
 const QUESTION_MODE = "question"
 
@@ -237,6 +243,18 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
           group: "Question",
           cmd: () => keymap.dispatchCommand("session.copy_mode"),
         })),
+        {
+          key: OPENCODE_COPY_MODE_ENTER_KEYS,
+          desc: "Enter copy mode",
+          group: "Question",
+          cmd: () => keymap.dispatchCommand("session.copy_mode"),
+        },
+        {
+          key: OPENCODE_COPY_MODE_TOGGLE_KEYS,
+          desc: "Enter copy mode",
+          group: "Question",
+          cmd: () => keymap.dispatchCommand("session.copy_mode"),
+        },
         {
           key: "left",
           desc: "Previous question",

--- a/packages/tui/test/keymap-vim.test.ts
+++ b/packages/tui/test/keymap-vim.test.ts
@@ -145,7 +145,7 @@ describe("opencode keymap", () => {
     expect(calls).toEqual(keys.map((key) => `copy:${key}`))
   })
 
-  test("question copy mode returns to question navigation after exit", () => {
+  test("question copy mode enters with vim-window keys and returns to question navigation", () => {
     const testKeymap = createTestKeymap({ defaultKeys: true })
     addons.registerCommaBindings(testKeymap.keymap)
     testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
@@ -204,68 +204,22 @@ describe("opencode keymap", () => {
     testKeymap.host.press("y")
     testKeymap.host.press("q")
     testKeymap.host.press("h")
-
-    expect(calls).toEqual(["copy:enter", "copy:navigate", "copy:yank", "copy:exit", "question:previous"])
-    expect(modeStack.current()).toBe(QUESTION_MODE)
-
-    popQuestion()
-    modeStack.dispose()
-  })
-
-  test("question copy mode can enter with vim-window toggle keys", () => {
-    const testKeymap = createTestKeymap({ defaultKeys: true })
-    addons.registerCommaBindings(testKeymap.keymap)
-    testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
-    const modeStack = createModeStack(testKeymap.keymap)
-    const calls: string[] = []
-    let popCopyMode: (() => void) | undefined
-
-    testKeymap.keymap.registerLayer({
-      commands: [
-        {
-          name: "session.copy_mode",
-          run() {
-            if (modeStack.current() === OPENCODE_COPY_MODE) {
-              popCopyMode?.()
-              popCopyMode = undefined
-              return
-            }
-            popCopyMode = modeStack.push(OPENCODE_COPY_MODE)
-            calls.push("copy:enter")
-          },
-        },
-      ],
-    })
-    testKeymap.keymap.registerLayer({
-      mode: QUESTION_MODE,
-      bindings: [
-        { key: OPENCODE_COPY_MODE_TOGGLE_KEYS, cmd: () => testKeymap.keymap.dispatchCommand("session.copy_mode") },
-        { key: "h", cmd: () => void calls.push("question:previous") },
-      ],
-    })
-    testKeymap.keymap.registerLayer({
-      mode: OPENCODE_COPY_MODE,
-      bindings: [
-        {
-          key: "q",
-          cmd: () => {
-            calls.push("copy:exit")
-            popCopyMode?.()
-            popCopyMode = undefined
-          },
-        },
-      ],
-    })
-
-    const popQuestion = modeStack.push(QUESTION_MODE)
     testKeymap.host.press("w", { ctrl: true })
-    expect(calls).toEqual([])
     expect(testKeymap.keymap.getPendingSequence().map((item) => item.display)).toEqual([`<${VIM_WINDOW_TOKEN}>`])
     testKeymap.host.press("w")
     testKeymap.host.press("q")
-    testKeymap.host.press("h")
+    testKeymap.host.press("l")
 
-    expect(calls).toEqual(["copy:enter", "copy:exit", "question:previous"])
+    expect(calls).toEqual([
+      "copy:enter",
+      "copy:navigate",
+      "copy:yank",
+      "copy:exit",
+      "question:previous",
+      "copy:enter",
+      "copy:exit",
+      "question:next",
+    ])
     expect(modeStack.current()).toBe(QUESTION_MODE)
 
     popQuestion()

--- a/packages/tui/test/keymap-vim.test.ts
+++ b/packages/tui/test/keymap-vim.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, test } from "bun:test"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import * as addons from "@opentui/keymap/addons/opentui"
-import { VIM_WINDOW_TOKEN } from "../src/keymap"
+import { OPENCODE_COPY_MODE, VIM_WINDOW_TOKEN } from "../src/keymap"
+
+const MODE_KEY = "test.mode"
+const QUESTION_MODE = "question"
+
+function createModeStack(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
+  const offFields = keymap.registerLayerFields({
+    mode(value, ctx) {
+      ctx.require(MODE_KEY, value)
+    },
+  })
+  const stack: string[] = []
+  const update = () => keymap.setData(MODE_KEY, stack.at(-1) ?? "base")
+
+  update()
+
+  return {
+    current: () => stack.at(-1) ?? "base",
+    push(mode: string) {
+      stack.push(mode)
+      update()
+      return () => {
+        const index = stack.lastIndexOf(mode)
+        if (index !== -1) stack.splice(index, 1)
+        update()
+      }
+    },
+    dispose: offFields,
+  }
+}
 
 describe("opencode keymap", () => {
   test("vim window token sequences can override exact ctrl+w input bindings by priority", () => {
@@ -109,5 +138,66 @@ describe("opencode keymap", () => {
     }
 
     expect(calls).toEqual(keys.map((key) => `copy:${key}`))
+  })
+
+  test("question copy mode returns to question navigation after exit", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    addons.registerCommaBindings(testKeymap.keymap)
+    const modeStack = createModeStack(testKeymap.keymap)
+    const calls: string[] = []
+    let popCopyMode: (() => void) | undefined
+
+    testKeymap.keymap.registerLayer({
+      commands: [
+        {
+          name: "session.copy_mode",
+          run() {
+            if (modeStack.current() === OPENCODE_COPY_MODE) {
+              popCopyMode?.()
+              popCopyMode = undefined
+              return
+            }
+            popCopyMode = modeStack.push(OPENCODE_COPY_MODE)
+            calls.push("copy:enter")
+          },
+        },
+      ],
+    })
+    testKeymap.keymap.registerLayer({
+      mode: QUESTION_MODE,
+      bindings: [
+        { key: "ctrl+v", cmd: () => testKeymap.keymap.dispatchCommand("session.copy_mode") },
+        { key: "h", cmd: () => void calls.push("question:previous") },
+        { key: "l", cmd: () => void calls.push("question:next") },
+      ],
+    })
+    testKeymap.keymap.registerLayer({
+      mode: OPENCODE_COPY_MODE,
+      bindings: [
+        { key: "j", cmd: () => void calls.push("copy:navigate") },
+        { key: "y", cmd: () => void calls.push("copy:yank") },
+        {
+          key: "q,escape",
+          cmd: () => {
+            calls.push("copy:exit")
+            popCopyMode?.()
+            popCopyMode = undefined
+          },
+        },
+      ],
+    })
+
+    const popQuestion = modeStack.push(QUESTION_MODE)
+    testKeymap.host.press("v", { ctrl: true })
+    testKeymap.host.press("j")
+    testKeymap.host.press("y")
+    testKeymap.host.press("q")
+    testKeymap.host.press("h")
+
+    expect(calls).toEqual(["copy:enter", "copy:navigate", "copy:yank", "copy:exit", "question:previous"])
+    expect(modeStack.current()).toBe(QUESTION_MODE)
+
+    popQuestion()
+    modeStack.dispose()
   })
 })

--- a/packages/tui/test/keymap-vim.test.ts
+++ b/packages/tui/test/keymap-vim.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import * as addons from "@opentui/keymap/addons/opentui"
-import { OPENCODE_COPY_MODE, VIM_WINDOW_TOKEN } from "../src/keymap"
+import {
+  OPENCODE_COPY_MODE,
+  OPENCODE_COPY_MODE_ENTER_KEYS,
+  OPENCODE_COPY_MODE_TOGGLE_KEYS,
+  VIM_WINDOW_TOKEN,
+} from "../src/keymap"
 
 const MODE_KEY = "test.mode"
 const QUESTION_MODE = "question"
@@ -143,6 +148,7 @@ describe("opencode keymap", () => {
   test("question copy mode returns to question navigation after exit", () => {
     const testKeymap = createTestKeymap({ defaultKeys: true })
     addons.registerCommaBindings(testKeymap.keymap)
+    testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
     const modeStack = createModeStack(testKeymap.keymap)
     const calls: string[] = []
     let popCopyMode: (() => void) | undefined
@@ -167,6 +173,8 @@ describe("opencode keymap", () => {
       mode: QUESTION_MODE,
       bindings: [
         { key: "ctrl+v", cmd: () => testKeymap.keymap.dispatchCommand("session.copy_mode") },
+        { key: OPENCODE_COPY_MODE_ENTER_KEYS, cmd: () => testKeymap.keymap.dispatchCommand("session.copy_mode") },
+        { key: OPENCODE_COPY_MODE_TOGGLE_KEYS, cmd: () => testKeymap.keymap.dispatchCommand("session.copy_mode") },
         { key: "h", cmd: () => void calls.push("question:previous") },
         { key: "l", cmd: () => void calls.push("question:next") },
       ],
@@ -188,7 +196,8 @@ describe("opencode keymap", () => {
     })
 
     const popQuestion = modeStack.push(QUESTION_MODE)
-    testKeymap.host.press("v", { ctrl: true })
+    testKeymap.host.press("w", { ctrl: true })
+    testKeymap.host.press("k")
     testKeymap.host.press("j")
     testKeymap.host.press("y")
     testKeymap.host.press("q")

--- a/packages/tui/test/keymap-vim.test.ts
+++ b/packages/tui/test/keymap-vim.test.ts
@@ -197,6 +197,8 @@ describe("opencode keymap", () => {
 
     const popQuestion = modeStack.push(QUESTION_MODE)
     testKeymap.host.press("w", { ctrl: true })
+    expect(calls).toEqual([])
+    expect(testKeymap.keymap.getPendingSequence().map((item) => item.display)).toEqual([`<${VIM_WINDOW_TOKEN}>`])
     testKeymap.host.press("k")
     testKeymap.host.press("j")
     testKeymap.host.press("y")
@@ -204,6 +206,66 @@ describe("opencode keymap", () => {
     testKeymap.host.press("h")
 
     expect(calls).toEqual(["copy:enter", "copy:navigate", "copy:yank", "copy:exit", "question:previous"])
+    expect(modeStack.current()).toBe(QUESTION_MODE)
+
+    popQuestion()
+    modeStack.dispose()
+  })
+
+  test("question copy mode can enter with vim-window toggle keys", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    addons.registerCommaBindings(testKeymap.keymap)
+    testKeymap.keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
+    const modeStack = createModeStack(testKeymap.keymap)
+    const calls: string[] = []
+    let popCopyMode: (() => void) | undefined
+
+    testKeymap.keymap.registerLayer({
+      commands: [
+        {
+          name: "session.copy_mode",
+          run() {
+            if (modeStack.current() === OPENCODE_COPY_MODE) {
+              popCopyMode?.()
+              popCopyMode = undefined
+              return
+            }
+            popCopyMode = modeStack.push(OPENCODE_COPY_MODE)
+            calls.push("copy:enter")
+          },
+        },
+      ],
+    })
+    testKeymap.keymap.registerLayer({
+      mode: QUESTION_MODE,
+      bindings: [
+        { key: OPENCODE_COPY_MODE_TOGGLE_KEYS, cmd: () => testKeymap.keymap.dispatchCommand("session.copy_mode") },
+        { key: "h", cmd: () => void calls.push("question:previous") },
+      ],
+    })
+    testKeymap.keymap.registerLayer({
+      mode: OPENCODE_COPY_MODE,
+      bindings: [
+        {
+          key: "q",
+          cmd: () => {
+            calls.push("copy:exit")
+            popCopyMode?.()
+            popCopyMode = undefined
+          },
+        },
+      ],
+    })
+
+    const popQuestion = modeStack.push(QUESTION_MODE)
+    testKeymap.host.press("w", { ctrl: true })
+    expect(calls).toEqual([])
+    expect(testKeymap.keymap.getPendingSequence().map((item) => item.display)).toEqual([`<${VIM_WINDOW_TOKEN}>`])
+    testKeymap.host.press("w")
+    testKeymap.host.press("q")
+    testKeymap.host.press("h")
+
+    expect(calls).toEqual(["copy:enter", "copy:exit", "question:previous"])
     expect(modeStack.current()).toBe(QUESTION_MODE)
 
     popQuestion()


### PR DESCRIPTION
### Summary

Copy/visual mode could only be entered after dismissing an interactive question.

The Prompt (and its copy subsystem) was unmounted while a question was active, and session.copy_mode was gated to base mode.

- Keep Prompt mounted (disabled) during a question via promptMounted + copyDuringModal
- Re-dispatch session.copy_mode from QUESTION_MODE bindings
- Push OPENCODE_COPY_MODE so the dialog's hjkl bindings yield to copy nav
- Centralize copy-mode stack ownership in one effect syncing vimState.isCopy(), and exit copy mode on q/escape in the vim handler

### Testing: 

Manual: copy mode enters/navigates/yanks over the transcript with the dialog visible, and q/esc/return return to dialog option nav. bun typecheck passes in packages/tui.

### Before - Fails to enter copy mode 

<img width="666" height="756" alt="Screenshot 2026-06-23 at 22 01 25" src="https://github.com/user-attachments/assets/4bbcb48e-a72f-4bfb-a1b6-729795ccae40" />


### After - Enters copy mode successfully

<img width="571" height="715" alt="Screenshot 2026-06-23 at 22 00 24" src="https://github.com/user-attachments/assets/eef9f095-d445-4eb8-8904-4236a20cec56" />