### PR TITLE
feat: start copy search from normal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Toggle via command palette > `Toggle vim mode`.
 | Matching / paragraph yanks     | `y%`, `y}`, `y{`                                           |
 | Put / undo / repeat            | `p`, `P`, `u`, `Ctrl+r`, `.`                               |
 | Visual selection               | `v`, `V`                                                   |
+| Chat history search            | `/`, `?`                                                   |
 | Commands                       | `:`, `:q`                                                  |
 
 Numeric count prefixes are supported for motions and common operators.

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -712,7 +712,13 @@ export function Prompt(props: PromptProps) {
       return props.copy?.previousParagraph() ?? false
     },
     copySearchStart(direction) {
-      props.copy?.searchStart(direction)
+      if (!props.copy) return false
+      if (!props.sessionID || !sync.data.message[props.sessionID]?.length) return false
+      if (!vimState.isCopy()) {
+        vimState.setMode("copy")
+        props.copy.enter()
+      }
+      props.copy.searchStart(direction)
     },
     copySearchAppend(value) {
       return props.copy?.searchAppend(value) ?? false

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -156,7 +156,7 @@ export function createVimHandler(input: {
   copyMatchingBracket?: () => boolean
   copyNextParagraph?: () => boolean
   copyPreviousParagraph?: () => boolean
-  copySearchStart?: (direction: VimSearchDirection) => void
+  copySearchStart?: (direction: VimSearchDirection) => boolean | void
   copySearchAppend?: (value: string) => boolean
   copySearchBackspace?: () => boolean
   copySearchSubmit?: () => boolean
@@ -1066,6 +1066,14 @@ export function createVimHandler(input: {
       input.state.clearPending()
       event.preventDefault()
       return true
+    }
+
+    if ((key === "/" || key === "?") && !hasModifier(event) && !hadPending && !hadCount) {
+      if (input.copySearchStart?.(key === "?" ? "backward" : "forward") !== false) {
+        input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
     }
 
     if (input.state.pending() === "c") {

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -1068,7 +1068,7 @@ export function createVimHandler(input: {
       return true
     }
 
-    if ((key === "/" || key === "?") && !hasModifier(event) && !hadPending && !hadCount) {
+    if ((key === "/" || key === "?") && !hasModifier(event) && !hadPending && !hadCount && !input.state.isVisual()) {
       if (input.copySearchStart?.(key === "?" ? "backward" : "forward") !== false) {
         input.state.clearPending()
         event.preventDefault()

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -172,6 +172,7 @@ function createHandler(
     data?: unknown
     snapshotDataEqual?: (before: unknown, after: unknown) => boolean
     langmap?: Record<string, string>
+    copySearchAvailable?: boolean
   },
 ) {
   const textarea = createTextarea(text, { strict: options?.strict })
@@ -508,6 +509,8 @@ function createHandler(
       return true
     },
     copySearchStart(direction) {
+      if (options?.copySearchAvailable === false) return false
+      if (!state.isCopy()) state.setMode("copy")
       copySearchCalls.push(direction)
       setCopySearchActive(true)
       setCopySearchHighlighted(true)
@@ -636,6 +639,38 @@ describe("vim motion handler", () => {
     expect(ctx.handler.handleKey(event.event)).toBe(true)
 
     expect(ctx.commandPaletteCalls).toHaveLength(1)
+    expect(event.prevented()).toBe(true)
+  })
+
+  test("normal slash starts forward copy search", () => {
+    const ctx = createHandler("abc")
+    const event = createEvent("slash")
+
+    expect(ctx.handler.handleKey(event.event)).toBe(true)
+
+    expect(ctx.copySearchCalls).toEqual(["forward"])
+    expect(event.prevented()).toBe(true)
+  })
+
+  test("normal question mark starts backward copy search", () => {
+    const ctx = createHandler("abc")
+    const event = createEvent("slash", { shift: true })
+
+    expect(ctx.handler.handleKey(event.event)).toBe(true)
+
+    expect(ctx.copySearchCalls).toEqual(["backward"])
+    expect(event.prevented()).toBe(true)
+  })
+
+  test("pending operator slash does not start copy search", () => {
+    const ctx = createHandler("abc")
+    ctx.handler.handleKey(createEvent("d").event)
+    const event = createEvent("slash")
+
+    expect(ctx.handler.handleKey(event.event)).toBe(true)
+
+    expect(ctx.copySearchCalls).toHaveLength(0)
+    expect(ctx.state.pending()).toBe("")
     expect(event.prevented()).toBe(true)
   })
 
@@ -2706,24 +2741,26 @@ describe("vim motion handler", () => {
     expect(ctx.state.typed()).toBe(false)
   })
 
-  test("/ and @ stay in normal mode without autocomplete", () => {
+  test("/ starts forward copy search and @ stays in normal mode without autocomplete", () => {
     const ctx = createHandler("abc", { mode: "normal" })
 
     const slash = createEvent("/")
     expect(ctx.handler.handleKey(slash.event)).toBe(true)
     expect(slash.prevented()).toBe(true)
-    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.mode()).toBe("copy")
+    expect(ctx.copySearchCalls).toEqual(["forward"])
 
     const at = createEvent("@")
     expect(ctx.handler.handleKey(at.event)).toBe(true)
     expect(at.prevented()).toBe(true)
-    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.mode()).toBe("copy")
   })
 
-  test("/ enters insert on empty input with autocomplete available", () => {
+  test("/ enters insert on empty input with autocomplete available when copy search is unavailable", () => {
     const ctx = createHandler("", {
       mode: "normal",
       autocomplete: () => false,
+      copySearchAvailable: false,
     })
     const slash = createEvent("/")
 
@@ -2731,6 +2768,7 @@ describe("vim motion handler", () => {
     expect(slash.prevented()).toBe(true)
     expect(ctx.state.mode()).toBe("insert")
     expect(ctx.textarea.plainText).toBe("/")
+    expect(ctx.copySearchCalls).toHaveLength(0)
   })
 
   test("@ enters insert on empty input with autocomplete available", () => {
@@ -2746,7 +2784,7 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.plainText).toBe("@")
   })
 
-  test("/ enters insert when OpenTUI reports the key name as slash", () => {
+  test("/ starts forward copy search when OpenTUI reports the key name as slash", () => {
     const ctx = createHandler("", {
       mode: "normal",
       autocomplete: () => false,
@@ -2755,8 +2793,9 @@ describe("vim motion handler", () => {
 
     expect(ctx.handler.handleKey(slash.event)).toBe(true)
     expect(slash.prevented()).toBe(true)
-    expect(ctx.state.mode()).toBe("insert")
-    expect(ctx.textarea.plainText).toBe("/")
+    expect(ctx.state.mode()).toBe("copy")
+    expect(ctx.textarea.plainText).toBe("")
+    expect(ctx.copySearchCalls).toEqual(["forward"])
   })
 
   test("@ enters insert when OpenTUI reports the shifted base key", () => {
@@ -2772,7 +2811,7 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.plainText).toBe("@")
   })
 
-  test("/ stays normal on non-empty input with autocomplete visible", () => {
+  test("/ starts copy search on non-empty input with autocomplete visible", () => {
     const ctx = createHandler("abc", {
       mode: "normal",
       autocomplete: () => "/",
@@ -2781,7 +2820,8 @@ describe("vim motion handler", () => {
 
     expect(ctx.handler.handleKey(slash.event)).toBe(true)
     expect(slash.prevented()).toBe(true)
-    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.mode()).toBe("copy")
+    expect(ctx.copySearchCalls).toEqual(["forward"])
   })
 
   test("submit from normal keeps mode and clears pending", () => {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -674,6 +674,18 @@ describe("vim motion handler", () => {
     expect(event.prevented()).toBe(true)
   })
 
+  test("visual slash does not start copy search", () => {
+    const ctx = createHandler("abc")
+    ctx.handler.handleKey(createEvent("v").event)
+    const event = createEvent("slash")
+
+    expect(ctx.handler.handleKey(event.event)).toBe(true)
+
+    expect(ctx.copySearchCalls).toHaveLength(0)
+    expect(ctx.state.mode()).toBe("visual")
+    expect(event.prevented()).toBe(true)
+  })
+
   test("count prefixes repeat normal motions and clear after use", () => {
     const ctx = createHandler("abcdef")
 


### PR DESCRIPTION
Starts chat search from normal mode:

 - `/` starts forward search
 - `?` starts backward search
