### PR TITLE
feat: toggle collapsed tool output from copy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Text selection from the chat session view.
 | `h`, `j`, `k`, `l`, arrow keys | Navigate                                                |
 | `v`, `V`, `Ctrl+V`             | Start character-wise, line-wise, or block selection     |
 | `y`, `yy`                      | Yank to the vim register                                |
-| `Enter`                        | Copy to the system clipboard                            |
+| `Enter`                        | Copy to the system clipboard or toggle expandable tool output |
 | `Y`                            | Yank to the vim register and scroll to the bottom       |
 | `Shift+Enter`                  | Copy to the system clipboard and scroll to the bottom   |
 | `Escape`                       | Exit visual mode                                        |

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -100,6 +100,7 @@ export type PromptProps = {
     yankLine: () => { text: string; linewise: boolean } | null
     yankMatchingBracket: () => { text: string; linewise: boolean } | null
     copy: () => Promise<void> | void
+    toggleCollapsed: () => boolean
     isVisual: () => boolean
     exitVisual: () => void
     visualMode: () => undefined | "char" | "line" | "block"
@@ -686,6 +687,9 @@ export function Prompt(props: PromptProps) {
     },
     copyCopy() {
       return props.copy?.copy()
+    },
+    copyToggleCollapsed() {
+      return props.copy?.toggleCollapsed() ?? false
     },
     copyIsVisual() {
       return props.copy?.isVisual() ?? false
@@ -1407,6 +1411,13 @@ export function Prompt(props: PromptProps) {
   onCleanup(restoreCopyModeSuspend)
 
   function submitFromTextarea() {
+    if (vimState.isCopy()) {
+      if (!props.copy?.isVisual() && props.copy?.toggleCollapsed()) return
+      props.copy?.copy()
+      props.copy?.exitPreserveScroll()
+      vimState.setMode("normal")
+      return
+    }
     if (store.mode !== "normal") {
       submit()
       return

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -1707,7 +1707,7 @@ export function createVimHandler(input: {
     }
 
     if (key === "return") {
-      if (!input.copyIsVisual?.() && input.copyToggleCollapsed?.()) {
+      if (!event.shift && !input.copyIsVisual?.() && input.copyToggleCollapsed?.()) {
         event.preventDefault()
         return true
       }

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -97,6 +97,7 @@ function vimEventText(event: VimKeyLike) {
 
 function normalizedKeyName(event: VimKeyLike) {
   if (event.name === "backspace" || event.sequence === "\b" || event.sequence === "\x7f" || event.raw === "\b" || event.raw === "\x7f") return "backspace"
+  if (event.name === "enter") return "return"
   if (event.name === "slash") return event.shift ? "?" : "/"
   if (event.name === "colon") return ":"
   if (event.name === "at") return "@"
@@ -148,6 +149,7 @@ export function createVimHandler(input: {
   copyYankMatchingBracket?: () => boolean
   copyToggleVisualEnd?: () => void
   copyCopy?: () => void
+  copyToggleCollapsed?: () => boolean
   copyIsVisual?: () => boolean
   copyJump?: (action: VimJump) => void
   copyWordNext?: (big: boolean) => boolean
@@ -1705,6 +1707,10 @@ export function createVimHandler(input: {
     }
 
     if (key === "return") {
+      if (!input.copyIsVisual?.() && input.copyToggleCollapsed?.()) {
+        event.preventDefault()
+        return true
+      }
       input.copyCopy?.()
       if (event.shift) {
         input.state.setMode("normal")

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -420,24 +420,34 @@ export function createCopyMode(input: {
 
   let compensateTimer: ReturnType<typeof setTimeout> | undefined
 
-  function viewportTop(scroll: ScrollBoxRenderable) {
+  function scrollOffset(scroll: ScrollBoxRenderable) {
     return scroll.scrollTop ?? scroll.y ?? 0
   }
 
-  function scrollToViewportTop(scroll: ScrollBoxRenderable, top: number) {
+  function viewportY(scroll: ScrollBoxRenderable) {
+    return scroll.y ?? 0
+  }
+
+  function scrollToOffset(scroll: ScrollBoxRenderable, top: number) {
     if (typeof scroll.scrollTo === "function") scroll.scrollTo(top)
-    else scroll.scrollBy(top - viewportTop(scroll))
+    else scroll.scrollBy(top - scrollOffset(scroll))
+  }
+
+  function scrollByScreenDelta(scroll: ScrollBoxRenderable, delta: number) {
+    if (delta === 0) return
+    scrollToOffset(scroll, scrollOffset(scroll) + delta)
   }
 
   function snapshotScroll() {
     const scr = input.scroll()
     if (!scr) return undefined
-    const scrollY = viewportTop(scr)
+    const scrollY = scrollOffset(scr)
+    const top = viewportY(scr)
     const atBottom = scr.scrollHeight > scr.height && scrollY + scr.height >= scr.scrollHeight - 1
     const children = scr.getChildren().toSorted((a, b) => a.y - b.y)
-    const ref = children.find((c) => c.id && c.y + c.height > scrollY)
+    const ref = children.find((c) => c.id && c.y + c.height > top)
     if (!ref?.id) return undefined
-    return { id: ref.id, childY: ref.y, scrollY, atBottom }
+    return { id: ref.id, childY: ref.y - top, scrollY, atBottom }
   }
 
   function compensateScroll(snap: ReturnType<typeof snapshotScroll>, afterSettle?: () => void, fast = false) {
@@ -453,14 +463,12 @@ export function createCopyMode(input: {
       const child = scr.getChildren().find((c) => c.id === snap.id)
       if (!child) return false
       const oldAbsolute = snap.scrollY + snap.childY
-      const newAbsolute = viewportTop(scr) + child.y
+      const newAbsolute = scrollOffset(scr) + child.y - viewportY(scr)
       const contentDelta = newAbsolute - oldAbsolute
       const cappedDelta = Math.max(-scr.height, Math.min(scr.height, contentDelta))
       if (contentDelta !== 0) {
-        if (snap.atBottom) {
-          if (typeof scr.scrollTo === "function") scr.scrollTo(scr.scrollHeight)
-          else scr.scrollBy(scr.scrollHeight - viewportTop(scr))
-        } else scrollToViewportTop(scr, snap.scrollY + cappedDelta)
+        if (snap.atBottom) scrollToOffset(scr, scr.scrollHeight)
+        else scrollToOffset(scr, snap.scrollY + cappedDelta)
       }
       return true
     }
@@ -1118,7 +1126,14 @@ export function createCopyMode(input: {
   }
 
   function preserveToolToggleOffset(id: string, offset: number, afterSettle?: () => void) {
-    settleToolToggle(id, (_, row) => scrollToViewportTop(input.scroll(), row.y - offset), afterSettle)
+    settleToolToggle(
+      id,
+      (_, row) => {
+        const scr = input.scroll()
+        scrollByScreenDelta(scr, row.y - viewportY(scr) - offset)
+      },
+      afterSettle,
+    )
   }
 
   function toggleCollapsed() {
@@ -1130,7 +1145,7 @@ export function createCopyMode(input: {
     if (lastToolToggleIndex(list, row.id) !== s.idx) return false
     const text = rowText(row).trim().toLowerCase()
     const expanding = text === "click to expand"
-    const offset = row.y - viewportTop(input.scroll())
+    const offset = row.y - viewportY(input.scroll())
     const targetID = row.id
     const toggled = Boolean(input.toggleCollapsed?.(row.id) || (row.part ? input.toggleCollapsed?.(row.part) : false))
     if (toggled) {

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -1083,8 +1083,8 @@ export function createCopyMode(input: {
           const list = rows()
           const idx = list.findIndex((candidate) => {
             if (candidate.id !== targetID && candidate.part !== targetPart) return false
-            const text = rowPadded(candidate).toLowerCase()
-            return text.includes("click to expand") || text.includes("click to collapse")
+            const text = rowText(candidate).trim().toLowerCase()
+            return text === "click to expand" || text === "click to collapse"
           })
           const next = list[idx]
           if (!next) return

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -1126,7 +1126,7 @@ export function createCopyMode(input: {
     if (!s.active) return false
     const list = rows()
     const row = list[s.idx]
-    if (!row) return false
+    if (!row || !isToolToggleRow(row)) return false
     if (lastToolToggleIndex(list, row.id) !== s.idx) return false
     const text = rowText(row).trim().toLowerCase()
     const expanding = text === "click to expand"
@@ -1406,7 +1406,7 @@ export function createCopyMode(input: {
     if (!s.active || s.visual) return undefined
     const list = rows()
     const row = list[s.idx]
-    if (!row || lastToolToggleIndex(list, row.id) !== s.idx) return undefined
+    if (!row || !isToolToggleRow(row) || lastToolToggleIndex(list, row.id) !== s.idx) return undefined
     const text = rowText(row).trim()
     if (!text) return undefined
     return { kind: "tool-toggle" as const, left: copyMin(row), text }

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -1081,17 +1081,17 @@ export function createCopyMode(input: {
     return list.findLastIndex((candidate) => candidate.id === id && isToolToggleRow(candidate))
   }
 
-  function preserveToolToggleOffset(id: string, offset: number, afterSettle?: () => void) {
+  function settleToolToggle(id: string, apply: (idx: number, row: CopyRow) => void, afterSettle?: () => void) {
     if (compensateTimer) clearTimeout(compensateTimer)
 
-    const tryPreserve = () => {
+    const tryApply = () => {
       const scr = input.scroll()
       if (!scr || scr.isDestroyed) return false
       const list = rows()
       const idx = lastToolToggleIndex(list, id)
       const next = list[idx]
       if (!next) return false
-      scrollToViewportTop(scr, next.y - offset)
+      apply(idx, next)
       return true
     }
 
@@ -1099,8 +1099,8 @@ export function createCopyMode(input: {
     let settled = false
     const poll = () => {
       attempts++
-      const preserved = tryPreserve()
-      if (preserved && !settled && attempts >= 2) {
+      const applied = tryApply()
+      if (applied && !settled && attempts >= 2) {
         settled = true
         afterSettle?.()
       }
@@ -1113,6 +1113,14 @@ export function createCopyMode(input: {
     compensateTimer = setTimeout(poll, 0)
   }
 
+  function revealToolToggle(id: string, afterSettle?: () => void) {
+    settleToolToggle(id, (idx) => sync(idx), afterSettle)
+  }
+
+  function preserveToolToggleOffset(id: string, offset: number, afterSettle?: () => void) {
+    settleToolToggle(id, (_, row) => scrollToViewportTop(input.scroll(), row.y - offset), afterSettle)
+  }
+
   function toggleCollapsed() {
     const s = state()
     if (!s.active) return false
@@ -1120,17 +1128,23 @@ export function createCopyMode(input: {
     const row = list[s.idx]
     if (!row) return false
     if (lastToolToggleIndex(list, row.id) !== s.idx) return false
+    const text = rowText(row).trim().toLowerCase()
+    const expanding = text === "click to expand"
     const offset = row.y - viewportTop(input.scroll())
     const targetID = row.id
     const toggled = Boolean(input.toggleCollapsed?.(row.id) || (row.part ? input.toggleCollapsed?.(row.part) : false))
     if (toggled) {
-      preserveToolToggleOffset(targetID, offset, () => {
+      const restoreCursor = () => {
         const list = rows()
         const idx = lastToolToggleIndex(list, targetID)
         const next = list[idx]
         if (!next) return
-        setState((prev) => ({ ...prev, active: true, idx, col: copyMin(next), stick: "first" }))
-      })
+        if (expanding) sync(idx)
+        else setState((prev) => ({ ...prev, active: true, idx }))
+        setState((prev) => ({ ...prev, col: copyMin(next), stick: "first" }))
+      }
+      if (expanding) revealToolToggle(targetID, restoreCursor)
+      else preserveToolToggleOffset(targetID, offset, restoreCursor)
     }
     return toggled
   }

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -1352,6 +1352,17 @@ export function createCopyMode(input: {
     return " "
   })
 
+  const action = createMemo(() => {
+    const s = state()
+    if (!s.active || s.visual) return undefined
+    const list = rows()
+    const row = list[s.idx]
+    if (!row || lastToolToggleIndex(list, row.id) !== s.idx) return undefined
+    const text = rowText(row).trim()
+    if (!text) return undefined
+    return { kind: "tool-toggle" as const, left: copyMin(row), text }
+  })
+
   return {
     prompt: {
       enter,
@@ -1407,5 +1418,6 @@ export function createCopyMode(input: {
     state,
     cursorCol,
     cursorText,
+    action,
   }
 }

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -1085,18 +1085,34 @@ export function createCopyMode(input: {
     return text === "click to expand" || text === "click to collapse"
   }
 
-  function lastToolToggleIndex(list: CopyRow[], id: string) {
-    return list.findLastIndex((candidate) => candidate.id === id && isToolToggleRow(candidate))
+  function toolToggleText(row: CopyRow) {
+    if (row.kind !== "tool") return undefined
+    const text = rowText(row).trim().toLowerCase()
+    if (text === "click to expand" || text === "click to collapse") return text
+    return undefined
   }
 
-  function settleToolToggle(id: string, apply: (idx: number, row: CopyRow) => void, afterSettle?: () => void) {
+  function lastToolToggleIndex(list: CopyRow[], id: string, expectedText?: string) {
+    return list.findLastIndex((candidate) => {
+      if (candidate.id !== id) return false
+      const text = toolToggleText(candidate)
+      return expectedText ? text === expectedText : !!text
+    })
+  }
+
+  function settleToolToggle(
+    id: string,
+    expectedText: string,
+    apply: (idx: number, row: CopyRow) => void,
+    afterSettle?: () => void,
+  ) {
     if (compensateTimer) clearTimeout(compensateTimer)
 
     const tryApply = () => {
       const scr = input.scroll()
       if (!scr || scr.isDestroyed) return false
       const list = rows()
-      const idx = lastToolToggleIndex(list, id)
+      const idx = lastToolToggleIndex(list, id, expectedText)
       const next = list[idx]
       if (!next) return false
       apply(idx, next)
@@ -1121,13 +1137,14 @@ export function createCopyMode(input: {
     compensateTimer = setTimeout(poll, 0)
   }
 
-  function revealToolToggle(id: string, afterSettle?: () => void) {
-    settleToolToggle(id, (idx) => sync(idx), afterSettle)
+  function revealToolToggle(id: string, expectedText: string, afterSettle?: () => void) {
+    settleToolToggle(id, expectedText, (idx) => sync(idx), afterSettle)
   }
 
-  function preserveToolToggleOffset(id: string, offset: number, afterSettle?: () => void) {
+  function preserveToolToggleOffset(id: string, expectedText: string, offset: number, afterSettle?: () => void) {
     settleToolToggle(
       id,
+      expectedText,
       (_, row) => {
         const scr = input.scroll()
         scrollByScreenDelta(scr, row.y - viewportY(scr) - offset)
@@ -1147,19 +1164,20 @@ export function createCopyMode(input: {
     const expanding = text === "click to expand"
     const offset = row.y - viewportY(input.scroll())
     const targetID = row.id
+    const expectedText = expanding ? "click to collapse" : "click to expand"
     const toggled = Boolean(input.toggleCollapsed?.(row.id) || (row.part ? input.toggleCollapsed?.(row.part) : false))
     if (toggled) {
       const restoreCursor = () => {
         const list = rows()
-        const idx = lastToolToggleIndex(list, targetID)
+        const idx = lastToolToggleIndex(list, targetID, expectedText)
         const next = list[idx]
         if (!next) return
         if (expanding) sync(idx)
         else setState((prev) => ({ ...prev, active: true, idx }))
         setState((prev) => ({ ...prev, col: copyMin(next), stick: "first" }))
       }
-      if (expanding) revealToolToggle(targetID, restoreCursor)
-      else preserveToolToggleOffset(targetID, offset, restoreCursor)
+      if (expanding) revealToolToggle(targetID, expectedText, restoreCursor)
+      else preserveToolToggleOffset(targetID, expectedText, offset, restoreCursor)
     }
     return toggled
   }

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -88,6 +88,7 @@ export function createCopyMode(input: {
   details: () => boolean
   session: Accessor<string>
   toBottom: () => void
+  toggleCollapsed?: (id: string) => boolean
 }) {
   const [state, setState] = createSignal<CopyState>({ ...empty })
   const [unified, setUnified] = createSignal(false)
@@ -1062,6 +1063,39 @@ export function createCopyMode(input: {
     await writeClipboard(text)
   }
 
+  function toggleCollapsed() {
+    const s = state()
+    if (!s.active) return false
+    const list = rows()
+    const row = list[s.idx]
+    if (!row) return false
+    const text = rowPadded(row).toLowerCase()
+    if (!text.includes("click to expand") && !text.includes("click to collapse")) return false
+    const snap = snapshotScroll()
+    const targetID = row.id
+    const targetPart = row.part
+    const toggled = Boolean(input.toggleCollapsed?.(row.id) || (row.part ? input.toggleCollapsed?.(row.part) : false))
+    if (toggled) {
+      compensateScroll(
+        snap,
+        () => {
+          const list = rows()
+          const idx = list.findIndex((candidate) => {
+            if (candidate.id !== targetID && candidate.part !== targetPart) return false
+            const text = rowPadded(candidate).toLowerCase()
+            return text.includes("click to expand") || text.includes("click to collapse")
+          })
+          const next = list[idx]
+          if (!next) return
+          sync(idx)
+          setState((prev) => ({ ...prev, col: copyMin(next), stick: "first" }))
+        },
+        true,
+      )
+    }
+    return toggled
+  }
+
   // --- jumps ---
 
   function jump(action: "top" | "bottom" | "high" | "middle" | "low") {
@@ -1325,6 +1359,7 @@ export function createCopyMode(input: {
       yankLine,
       yankMatchingBracket,
       copy,
+      toggleCollapsed,
       isVisual: () => !!state().visual,
       exitVisual,
       visualMode: () => state().visual,

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -1063,29 +1063,32 @@ export function createCopyMode(input: {
     await writeClipboard(text)
   }
 
+  function isToolToggleRow(row: CopyRow) {
+    if (row.kind !== "tool") return false
+    const text = rowText(row).trim().toLowerCase()
+    return text === "click to expand" || text === "click to collapse"
+  }
+
+  function lastToolToggleIndex(list: CopyRow[], id: string) {
+    return list.findLastIndex((candidate) => candidate.id === id && isToolToggleRow(candidate))
+  }
+
   function toggleCollapsed() {
     const s = state()
     if (!s.active) return false
     const list = rows()
     const row = list[s.idx]
     if (!row) return false
-    if (row.kind !== "tool") return false
-    const text = rowText(row).trim().toLowerCase()
-    if (text !== "click to expand" && text !== "click to collapse") return false
+    if (lastToolToggleIndex(list, row.id) !== s.idx) return false
     const snap = snapshotScroll()
     const targetID = row.id
-    const targetPart = row.part
     const toggled = Boolean(input.toggleCollapsed?.(row.id) || (row.part ? input.toggleCollapsed?.(row.part) : false))
     if (toggled) {
       compensateScroll(
         snap,
         () => {
           const list = rows()
-          const idx = list.findIndex((candidate) => {
-            if (candidate.id !== targetID && candidate.part !== targetPart) return false
-            const text = rowText(candidate).trim().toLowerCase()
-            return text === "click to expand" || text === "click to collapse"
-          })
+          const idx = lastToolToggleIndex(list, targetID)
           const next = list[idx]
           if (!next) return
           sync(idx)

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -1069,8 +1069,9 @@ export function createCopyMode(input: {
     const list = rows()
     const row = list[s.idx]
     if (!row) return false
-    const text = rowPadded(row).toLowerCase()
-    if (!text.includes("click to expand") && !text.includes("click to collapse")) return false
+    if (row.kind !== "tool") return false
+    const text = rowText(row).trim().toLowerCase()
+    if (text !== "click to expand" && text !== "click to collapse") return false
     const snap = snapshotScroll()
     const targetID = row.id
     const targetPart = row.part

--- a/packages/tui/src/routes/session/copy-mode.ts
+++ b/packages/tui/src/routes/session/copy-mode.ts
@@ -420,13 +420,22 @@ export function createCopyMode(input: {
 
   let compensateTimer: ReturnType<typeof setTimeout> | undefined
 
+  function viewportTop(scroll: ScrollBoxRenderable) {
+    return scroll.scrollTop ?? scroll.y ?? 0
+  }
+
+  function scrollToViewportTop(scroll: ScrollBoxRenderable, top: number) {
+    if (typeof scroll.scrollTo === "function") scroll.scrollTo(top)
+    else scroll.scrollBy(top - viewportTop(scroll))
+  }
+
   function snapshotScroll() {
     const scr = input.scroll()
     if (!scr) return undefined
-    const scrollY = scr.scrollTop ?? scr.y ?? 0
+    const scrollY = viewportTop(scr)
     const atBottom = scr.scrollHeight > scr.height && scrollY + scr.height >= scr.scrollHeight - 1
     const children = scr.getChildren().toSorted((a, b) => a.y - b.y)
-    const ref = children.find((c) => c.id && c.y + c.height > scr.y)
+    const ref = children.find((c) => c.id && c.y + c.height > scrollY)
     if (!ref?.id) return undefined
     return { id: ref.id, childY: ref.y, scrollY, atBottom }
   }
@@ -444,15 +453,14 @@ export function createCopyMode(input: {
       const child = scr.getChildren().find((c) => c.id === snap.id)
       if (!child) return false
       const oldAbsolute = snap.scrollY + snap.childY
-      const newAbsolute = (scr.scrollTop ?? scr.y ?? 0) + child.y
+      const newAbsolute = viewportTop(scr) + child.y
       const contentDelta = newAbsolute - oldAbsolute
       const cappedDelta = Math.max(-scr.height, Math.min(scr.height, contentDelta))
       if (contentDelta !== 0) {
         if (snap.atBottom) {
           if (typeof scr.scrollTo === "function") scr.scrollTo(scr.scrollHeight)
-          else scr.scrollBy(scr.scrollHeight - (scr.scrollTop ?? scr.y ?? 0))
-        } else if (typeof scr.scrollTo === "function") scr.scrollTo(snap.scrollY + cappedDelta)
-        else scr.scrollBy(cappedDelta)
+          else scr.scrollBy(scr.scrollHeight - viewportTop(scr))
+        } else scrollToViewportTop(scr, snap.scrollY + cappedDelta)
       }
       return true
     }
@@ -1073,6 +1081,38 @@ export function createCopyMode(input: {
     return list.findLastIndex((candidate) => candidate.id === id && isToolToggleRow(candidate))
   }
 
+  function preserveToolToggleOffset(id: string, offset: number, afterSettle?: () => void) {
+    if (compensateTimer) clearTimeout(compensateTimer)
+
+    const tryPreserve = () => {
+      const scr = input.scroll()
+      if (!scr || scr.isDestroyed) return false
+      const list = rows()
+      const idx = lastToolToggleIndex(list, id)
+      const next = list[idx]
+      if (!next) return false
+      scrollToViewportTop(scr, next.y - offset)
+      return true
+    }
+
+    let attempts = 0
+    let settled = false
+    const poll = () => {
+      attempts++
+      const preserved = tryPreserve()
+      if (preserved && !settled && attempts >= 2) {
+        settled = true
+        afterSettle?.()
+      }
+      if (attempts >= 10) {
+        if (!settled) afterSettle?.()
+        return
+      }
+      compensateTimer = setTimeout(poll, attempts < 4 ? 4 : 16)
+    }
+    compensateTimer = setTimeout(poll, 0)
+  }
+
   function toggleCollapsed() {
     const s = state()
     if (!s.active) return false
@@ -1080,22 +1120,17 @@ export function createCopyMode(input: {
     const row = list[s.idx]
     if (!row) return false
     if (lastToolToggleIndex(list, row.id) !== s.idx) return false
-    const snap = snapshotScroll()
+    const offset = row.y - viewportTop(input.scroll())
     const targetID = row.id
     const toggled = Boolean(input.toggleCollapsed?.(row.id) || (row.part ? input.toggleCollapsed?.(row.part) : false))
     if (toggled) {
-      compensateScroll(
-        snap,
-        () => {
-          const list = rows()
-          const idx = lastToolToggleIndex(list, targetID)
-          const next = list[idx]
-          if (!next) return
-          sync(idx)
-          setState((prev) => ({ ...prev, col: copyMin(next), stick: "first" }))
-        },
-        true,
-      )
+      preserveToolToggleOffset(targetID, offset, () => {
+        const list = rows()
+        const idx = lastToolToggleIndex(list, targetID)
+        const next = list[idx]
+        if (!next) return
+        setState((prev) => ({ ...prev, active: true, idx, col: copyMin(next), stick: "first" }))
+      })
     }
     return toggled
   }

--- a/packages/tui/src/routes/session/copy-overlay.tsx
+++ b/packages/tui/src/routes/session/copy-overlay.tsx
@@ -3,7 +3,13 @@ import { RGBA } from "@opentui/core"
 import { selectedForeground, useTheme } from "../../context/theme"
 import type { CopyHighlight, CopyRow } from "./copy-mode"
 
-export type CopyPosition = { line: number; col: number; visual: boolean; cursorText: string }
+export type CopyPosition = {
+  line: number
+  col: number
+  visual: boolean
+  cursorText: string
+  action?: { kind: "tool-toggle"; left: number; text: string }
+}
 export type CopyContext = CopyRow & CopyPosition
 
 export function CopyOverlay(props: { copy?: CopyPosition; topOffset?: number; highlights?: CopyHighlight[] }) {
@@ -24,6 +30,15 @@ export function CopyOverlay(props: { copy?: CopyPosition; topOffset?: number; hi
           height={1}
           backgroundColor={RGBA.fromInts(255, 255, 255, 15)}
         />
+      </Show>
+      <Show when={!props.copy?.visual ? props.copy?.action : undefined}>
+        {(action) => (
+          <box position="absolute" top={top(props.copy!.line)} left={action().left}>
+            <text bg={RGBA.fromInts(255, 255, 255, 25)} fg={theme.textMuted}>
+              {action().text}
+            </text>
+          </box>
+        )}
       </Show>
       <For each={props.highlights ?? []}>
         {(highlight) => {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1302,6 +1302,7 @@ export function Session() {
                                   col: cm.cursorCol(),
                                   visual: !!cm.state().visual,
                                   cursorText: cm.cursorText(),
+                                  action: cm.action(),
                                 }
                               : undefined
                           }
@@ -1331,6 +1332,7 @@ export function Session() {
                                   col: cm.cursorCol(),
                                   visual: !!cm.state().visual,
                                   cursorText: cm.cursorText(),
+                                  action: cm.action(),
                                 }
                               : undefined
                           }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -167,6 +167,7 @@ const context = createContext<{
   showGenericToolOutput: () => boolean
   showHints: () => boolean
   diffWrapMode: () => "word" | "none"
+  registerCollapsedToggle: (id: string, toggle: () => void) => () => void
   providers: () => ReadonlyMap<string, Provider>
   sync: ReturnType<typeof useSync>
   tui: ReturnType<typeof useTuiConfig>
@@ -246,6 +247,13 @@ export function Session() {
 
   let scroll!: ScrollBoxRenderable
   let prompt: PromptRef | undefined
+  const collapsedToggles = new Map<string, () => void>()
+  const registerCollapsedToggle = (id: string, toggle: () => void) => {
+    collapsedToggles.set(id, toggle)
+    return () => {
+      if (collapsedToggles.get(id) === toggle) collapsedToggles.delete(id)
+    }
+  }
 
   const cm = createCopyMode({
     scroll: () => scroll,
@@ -259,6 +267,12 @@ export function Session() {
         if (!scroll || scroll.isDestroyed) return
         scroll.scrollTo(scroll.scrollHeight)
       }, 50)
+    },
+    toggleCollapsed(id) {
+      const toggle = collapsedToggles.get(id)
+      if (!toggle) return false
+      toggle()
+      return true
     },
   })
 
@@ -1185,6 +1199,7 @@ export function Session() {
           showGenericToolOutput,
           showHints,
           diffWrapMode,
+          registerCollapsedToggle,
           providers,
           sync,
           tui: tuiConfig,
@@ -1918,6 +1933,18 @@ function GenericTool(props: ToolProps) {
     return collapsed().output
   })
 
+  createEffect(() => {
+    if (!collapsed().overflow) return
+    const unregisterID = ctx.registerCollapsedToggle(`tool-${props.part.messageID}-${props.part.id}`, () =>
+      setExpanded((prev) => !prev),
+    )
+    const unregisterPart = ctx.registerCollapsedToggle(props.part.id, () => setExpanded((prev) => !prev))
+    onCleanup(() => {
+      unregisterID()
+      unregisterPart()
+    })
+  })
+
   return (
     <Show
       when={props.output && ctx.showGenericToolOutput()}
@@ -2164,6 +2191,18 @@ function Shell(props: ToolProps) {
   const limited = createMemo(() => {
     if (expanded() || !collapsed().overflow) return output()
     return collapsed().output
+  })
+
+  createEffect(() => {
+    if (!collapsed().overflow) return
+    const unregisterID = ctx.registerCollapsedToggle(`tool-${props.part.messageID}-${props.part.id}`, () =>
+      setExpanded((prev) => !prev),
+    )
+    const unregisterPart = ctx.registerCollapsedToggle(props.part.id, () => setExpanded((prev) => !prev))
+    onCleanup(() => {
+      unregisterID()
+      unregisterPart()
+    })
   })
 
   const workdirDisplay = createMemo(() => {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -8006,6 +8006,102 @@ describe("copy mode", () => {
     expect(cm.action()).toMatchObject({ kind: "tool-toggle", text: "Click to collapse" })
   })
 
+  test("copy mode tool toggle waits for updated label before restoring cursor", async () => {
+    const collapsedLines = ["# Shell", "$ echo hello", "hello", "Click to expand"]
+    const expandedLines = [
+      "# Shell",
+      "$ echo hello",
+      ...Array.from({ length: 12 }, (_, i) => `output ${i}`),
+      "Click to collapse",
+    ]
+    let lines = expandedLines
+    let scrollY = 19
+    const childTop = 20
+    const child = {
+      id: "tool-message-part",
+      get y() {
+        return childTop - scrollY
+      },
+      get height() {
+        return lines.length
+      },
+      getChildren: () => [
+        {
+          _y: 0,
+          get plainText() {
+            return lines.join("\n")
+          },
+          lineInfo: {
+            get lineSources() {
+              return lines.map((_, i) => i)
+            },
+            get lineStartCols() {
+              return lines.map(() => 0)
+            },
+            get lineWidthCols() {
+              return lines.map((line) => Bun.stringWidth(line))
+            },
+            get lineWraps() {
+              return lines.map(() => 0)
+            },
+          },
+        },
+      ],
+    }
+    const scroll = {
+      y: 0,
+      get scrollTop() {
+        return scrollY
+      },
+      height: 10,
+      width: 120,
+      get scrollHeight() {
+        return childTop + lines.length + 20
+      },
+      getChildren: () => [child],
+      scrollBy(delta: number) {
+        scrollY += delta
+      },
+      scrollTo(top: number) {
+        scrollY = top
+      },
+    } as unknown as ScrollBoxRenderable
+    const cm = createCopyMode({
+      scroll: () => scroll,
+      messages: () => [{ id: "message", role: "assistant" }],
+      parts: () =>
+        [
+          {
+            id: "part",
+            messageID: "message",
+            type: "tool",
+            tool: "bash",
+            state: { status: "completed", input: {}, output: "hello" },
+          } as Part,
+        ],
+      thinking: () => false,
+      details: () => true,
+      session: () => "session",
+      toBottom() {},
+      toggleCollapsed() {
+        setTimeout(() => {
+          lines = collapsedLines
+        }, 25)
+        return true
+      },
+    })
+
+    cm.prompt.enter()
+    cm.prompt.jump("bottom")
+    expect(cm.prompt.text().trim()).toBe("Click to collapse")
+
+    expect(cm.prompt.toggleCollapsed()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(cm.prompt.text().trim()).toBe("Click to expand")
+    expect(cm.action()).toMatchObject({ kind: "tool-toggle", text: "Click to expand" })
+  })
+
   test("copy mode tool toggle reveals expanded output and preserves collapse offset", async () => {
     const collapsedLines = ["# Shell", "$ echo hello", "hello", "Click to expand"]
     const expandedLines = [

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -163,6 +163,7 @@ function createHandler(
       idx?: number
       rows?: Array<{ col: number }>
       isVisual?: boolean
+      toggleCollapsed?: () => boolean
     }
     register?: {
       get?: () => { text: string; linewise: boolean } | null
@@ -228,6 +229,7 @@ function createHandler(
   let copyYanks = 0
   let copyYankLines = 0
   let copyCopies = 0
+  let copyToggleCollapseds = 0
   let copyExitVisuals = 0
   let copyExits = 0
   const copyExitArgs: Array<boolean | undefined> = []
@@ -452,6 +454,10 @@ function createHandler(
     copyCopy() {
       copyCopies++
     },
+    copyToggleCollapsed() {
+      copyToggleCollapseds++
+      return options?.copy?.toggleCollapsed?.() ?? false
+    },
     copyIsVisual() {
       return copyVisual() !== undefined
     },
@@ -602,6 +608,7 @@ function createHandler(
     copyYanks: () => copyYanks,
     copyYankLines: () => copyYankLines,
     copyCopies: () => copyCopies,
+    copyToggleCollapseds: () => copyToggleCollapseds,
     copyExitVisuals: () => copyExitVisuals,
     copyExits: () => copyExits,
     copyExitArgs,
@@ -9365,6 +9372,19 @@ describe("copy mode", () => {
     expect(evt.prevented()).toBe(true)
     expect(ctx.copyCopies()).toBe(1)
     expect(ctx.copyYanks()).toBe(0)
+    expect(ctx.copyExits()).toBe(1)
+    expect(ctx.copyExitPreserveScrolls()).toBe(0)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("shift+return copies instead of toggling collapsed tool output", () => {
+    const ctx = createHandler("abc", { mode: "copy", copy: { toggleCollapsed: () => true } })
+
+    const evt = createEvent("return", { shift: true })
+    expect(ctx.handler.handleKey(evt.event)).toBe(true)
+    expect(evt.prevented()).toBe(true)
+    expect(ctx.copyToggleCollapseds()).toBe(0)
+    expect(ctx.copyCopies()).toBe(1)
     expect(ctx.copyExits()).toBe(1)
     expect(ctx.copyExitPreserveScrolls()).toBe(0)
     expect(ctx.state.mode()).toBe("normal")

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -7904,6 +7904,84 @@ describe("copy mode", () => {
     expect(cm.prompt.yankLine()).toEqual({ text: `- ${line}`, linewise: false })
   })
 
+  test("copy mode toggles collapsed tool output and keeps cursor on toggle row", async () => {
+    let toggles = 0
+    let lines = ["# Shell", "$ echo hello", "hello", "Click to expand"]
+    const child = {
+      id: "tool-message-part",
+      y: 0,
+      get height() {
+        return lines.length
+      },
+      getChildren: () => [
+        {
+          _y: 0,
+          get plainText() {
+            return lines.join("\n")
+          },
+          lineInfo: {
+            get lineSources() {
+              return lines.map((_, i) => i)
+            },
+            get lineStartCols() {
+              return lines.map(() => 0)
+            },
+            get lineWidthCols() {
+              return lines.map((line) => Bun.stringWidth(line))
+            },
+            get lineWraps() {
+              return lines.map(() => 0)
+            },
+          },
+        },
+      ],
+    }
+    const scroll = {
+      y: 0,
+      height: 10,
+      width: 120,
+      get scrollHeight() {
+        return lines.length
+      },
+      getChildren: () => [child],
+      scrollBy() {},
+    } as unknown as ScrollBoxRenderable
+    const cm = createCopyMode({
+      scroll: () => scroll,
+      messages: () => [{ id: "message", role: "assistant" }],
+      parts: () =>
+        [
+          {
+            id: "part",
+            messageID: "message",
+            type: "tool",
+            tool: "bash",
+            state: { status: "completed", input: {}, output: "hello" },
+          } as Part,
+        ],
+      thinking: () => false,
+      details: () => true,
+      session: () => "session",
+      toBottom() {},
+      toggleCollapsed(id) {
+        expect(id).toBe("tool-message-part")
+        toggles++
+        lines = ["# Shell", "$ echo hello", "hello", "more output", "Click to collapse"]
+        return true
+      },
+    })
+
+    cm.prompt.enter()
+    cm.prompt.jump("bottom")
+
+    expect(cm.prompt.text()).toContain("Click to expand")
+    expect(cm.prompt.toggleCollapsed()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(toggles).toBe(1)
+    expect(cm.prompt.text()).toContain("Click to collapse")
+  })
+
   test("yank line includes visible same-row prefixes", () => {
     const line = "Inspect current branch"
     const child = {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -8016,9 +8016,12 @@ describe("copy mode", () => {
     ]
     let lines = collapsedLines
     let scrollY = 19
+    const childTop = 20
     const child = {
       id: "tool-message-part",
-      y: 20,
+      get y() {
+        return childTop - scrollY
+      },
       get height() {
         return lines.length
       },
@@ -8046,13 +8049,14 @@ describe("copy mode", () => {
       ],
     }
     const scroll = {
-      get y() {
+      y: 0,
+      get scrollTop() {
         return scrollY
       },
       height: 10,
       width: 120,
       get scrollHeight() {
-        return child.y + lines.length + 20
+        return childTop + lines.length + 20
       },
       getChildren: () => [child],
       scrollBy(delta: number) {
@@ -8094,19 +8098,19 @@ describe("copy mode", () => {
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(cm.prompt.text().trim()).toBe("Click to collapse")
-    expect(scrollY).toBe(child.y + expandedLines.length - scroll.height)
+    expect(scrollY).toBe(childTop + expandedLines.length - scroll.height)
 
     expect(cm.prompt.toggleCollapsed()).toBe(true)
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(cm.prompt.text().trim()).toBe("Click to expand")
-    expect(scrollY).toBe(child.y + collapsedLines.length - scroll.height)
+    expect(scrollY).toBe(childTop + collapsedLines.length - scroll.height)
 
     expect(cm.prompt.toggleCollapsed()).toBe(true)
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(cm.prompt.text().trim()).toBe("Click to collapse")
-    expect(scrollY).toBe(child.y + expandedLines.length - scroll.height)
+    expect(scrollY).toBe(childTop + expandedLines.length - scroll.height)
   })
 
   test("yank line includes visible same-row prefixes", () => {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -7906,7 +7906,7 @@ describe("copy mode", () => {
 
   test("copy mode toggles collapsed tool output and keeps cursor on toggle row", async () => {
     let toggles = 0
-    let lines = ["# Shell", "$ echo hello", "hello click to expand world", "Click to expand"]
+    let lines = ["# Shell", "$ echo hello", "Click to expand", "hello click to expand world", "Click to expand"]
     const child = {
       id: "tool-message-part",
       y: 0,
@@ -7966,7 +7966,7 @@ describe("copy mode", () => {
       toggleCollapsed(id) {
         expect(id).toBe("tool-message-part")
         toggles++
-        lines = ["# Shell", "$ echo hello", "hello click to collapse world", "more output", "Click to collapse"]
+        lines = ["# Shell", "$ echo hello", "Click to collapse", "hello click to collapse world", "more output", "Click to collapse"]
         return true
       },
     })
@@ -7976,6 +7976,11 @@ describe("copy mode", () => {
     cm.prompt.move("down")
     cm.prompt.move("down")
 
+    expect(cm.prompt.text().trim()).toBe("Click to expand")
+    expect(cm.prompt.toggleCollapsed()).toBe(false)
+    expect(toggles).toBe(0)
+
+    cm.prompt.move("down")
     expect(cm.prompt.text()).toContain("hello click to expand world")
     expect(cm.prompt.toggleCollapsed()).toBe(false)
     expect(toggles).toBe(0)

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -7999,7 +7999,7 @@ describe("copy mode", () => {
     expect(cm.action()).toMatchObject({ kind: "tool-toggle", text: "Click to collapse" })
   })
 
-  test("copy mode tool toggle preserves cursor viewport offset", async () => {
+  test("copy mode tool toggle reveals expanded output and preserves collapse offset", async () => {
     const collapsedLines = ["# Shell", "$ echo hello", "hello", "Click to expand"]
     const expandedLines = [
       "# Shell",
@@ -8087,13 +8087,19 @@ describe("copy mode", () => {
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(cm.prompt.text().trim()).toBe("Click to collapse")
-    expect(scrollY).toBe(20 + expandedLines.length - 1 - 4)
+    expect(scrollY).toBe(child.y + expandedLines.length - scroll.height)
 
     expect(cm.prompt.toggleCollapsed()).toBe(true)
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(cm.prompt.text().trim()).toBe("Click to expand")
-    expect(scrollY).toBe(19)
+    expect(scrollY).toBe(child.y + collapsedLines.length - scroll.height)
+
+    expect(cm.prompt.toggleCollapsed()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(cm.prompt.text().trim()).toBe("Click to collapse")
+    expect(scrollY).toBe(child.y + expandedLines.length - scroll.height)
   })
 
   test("yank line includes visible same-row prefixes", () => {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -7906,7 +7906,7 @@ describe("copy mode", () => {
 
   test("copy mode toggles collapsed tool output and keeps cursor on toggle row", async () => {
     let toggles = 0
-    let lines = ["# Shell", "$ echo hello", "hello", "Click to expand"]
+    let lines = ["# Shell", "$ echo hello", "hello click to expand world", "Click to expand"]
     const child = {
       id: "tool-message-part",
       y: 0,
@@ -7972,6 +7972,14 @@ describe("copy mode", () => {
     })
 
     cm.prompt.enter()
+    cm.prompt.jump("top")
+    cm.prompt.move("down")
+    cm.prompt.move("down")
+
+    expect(cm.prompt.text()).toContain("hello click to expand world")
+    expect(cm.prompt.toggleCollapsed()).toBe(false)
+    expect(toggles).toBe(0)
+
     cm.prompt.jump("bottom")
 
     expect(cm.prompt.text()).toContain("Click to expand")

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -7999,6 +7999,103 @@ describe("copy mode", () => {
     expect(cm.action()).toMatchObject({ kind: "tool-toggle", text: "Click to collapse" })
   })
 
+  test("copy mode tool toggle preserves cursor viewport offset", async () => {
+    const collapsedLines = ["# Shell", "$ echo hello", "hello", "Click to expand"]
+    const expandedLines = [
+      "# Shell",
+      "$ echo hello",
+      ...Array.from({ length: 12 }, (_, i) => `output ${i}`),
+      "Click to collapse",
+    ]
+    let lines = collapsedLines
+    let scrollY = 19
+    const child = {
+      id: "tool-message-part",
+      y: 20,
+      get height() {
+        return lines.length
+      },
+      getChildren: () => [
+        {
+          _y: 0,
+          get plainText() {
+            return lines.join("\n")
+          },
+          lineInfo: {
+            get lineSources() {
+              return lines.map((_, i) => i)
+            },
+            get lineStartCols() {
+              return lines.map(() => 0)
+            },
+            get lineWidthCols() {
+              return lines.map((line) => Bun.stringWidth(line))
+            },
+            get lineWraps() {
+              return lines.map(() => 0)
+            },
+          },
+        },
+      ],
+    }
+    const scroll = {
+      get y() {
+        return scrollY
+      },
+      height: 10,
+      width: 120,
+      get scrollHeight() {
+        return child.y + lines.length + 20
+      },
+      getChildren: () => [child],
+      scrollBy(delta: number) {
+        scrollY += delta
+      },
+      scrollTo(top: number) {
+        scrollY = top
+      },
+    } as unknown as ScrollBoxRenderable
+    const cm = createCopyMode({
+      scroll: () => scroll,
+      messages: () => [{ id: "message", role: "assistant" }],
+      parts: () =>
+        [
+          {
+            id: "part",
+            messageID: "message",
+            type: "tool",
+            tool: "bash",
+            state: { status: "completed", input: {}, output: "hello" },
+          } as Part,
+        ],
+      thinking: () => false,
+      details: () => true,
+      session: () => "session",
+      toBottom() {},
+      toggleCollapsed() {
+        lines = lines === collapsedLines ? expandedLines : collapsedLines
+        return true
+      },
+    })
+
+    cm.prompt.enter()
+    cm.prompt.jump("bottom")
+    expect(cm.prompt.text().trim()).toBe("Click to expand")
+    expect(scrollY).toBe(19)
+
+    expect(cm.prompt.toggleCollapsed()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(cm.prompt.text().trim()).toBe("Click to collapse")
+    expect(scrollY).toBe(20 + expandedLines.length - 1 - 4)
+
+    expect(cm.prompt.toggleCollapsed()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(cm.prompt.text().trim()).toBe("Click to expand")
+    expect(scrollY).toBe(19)
+  })
+
   test("yank line includes visible same-row prefixes", () => {
     const line = "Inspect current branch"
     const child = {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -7977,22 +7977,26 @@ describe("copy mode", () => {
     cm.prompt.move("down")
 
     expect(cm.prompt.text().trim()).toBe("Click to expand")
+    expect(cm.action()).toBeUndefined()
     expect(cm.prompt.toggleCollapsed()).toBe(false)
     expect(toggles).toBe(0)
 
     cm.prompt.move("down")
     expect(cm.prompt.text()).toContain("hello click to expand world")
+    expect(cm.action()).toBeUndefined()
     expect(cm.prompt.toggleCollapsed()).toBe(false)
     expect(toggles).toBe(0)
 
     cm.prompt.jump("bottom")
 
     expect(cm.prompt.text()).toContain("Click to expand")
+    expect(cm.action()).toMatchObject({ kind: "tool-toggle", text: "Click to expand" })
     expect(cm.prompt.toggleCollapsed()).toBe(true)
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(toggles).toBe(1)
     expect(cm.prompt.text().trim()).toBe("Click to collapse")
+    expect(cm.action()).toMatchObject({ kind: "tool-toggle", text: "Click to collapse" })
   })
 
   test("yank line includes visible same-row prefixes", () => {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -7966,7 +7966,7 @@ describe("copy mode", () => {
       toggleCollapsed(id) {
         expect(id).toBe("tool-message-part")
         toggles++
-        lines = ["# Shell", "$ echo hello", "hello", "more output", "Click to collapse"]
+        lines = ["# Shell", "$ echo hello", "hello click to collapse world", "more output", "Click to collapse"]
         return true
       },
     })
@@ -7987,7 +7987,7 @@ describe("copy mode", () => {
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(toggles).toBe(1)
-    expect(cm.prompt.text()).toContain("Click to collapse")
+    expect(cm.prompt.text().trim()).toBe("Click to collapse")
   })
 
   test("yank line includes visible same-row prefixes", () => {


### PR DESCRIPTION
Closes #191

Allows `enter` to expand/collapse tool output in copy-mode when the cursor is on the `Click to expand`/ `Click to collapse` row.
