### PR TITLE
feat: add modal controls for dialog inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,24 +87,24 @@ Text selection from the chat session view.
 
 > Copy mode collapses code diffs into a single column for easy copying.
 
-| Keys                           | Action                                                  |
-| ------------------------------ | ------------------------------------------------------- |
-| `<leader>v`, `Ctrl+W k`        | Enter copy mode                                         |
-| `h`, `j`, `k`, `l`, arrow keys | Navigate                                                |
-| `v`, `V`, `Ctrl+V`             | Start character-wise, line-wise, or block selection     |
-| `y`, `yy`                      | Yank to the vim register                                |
+| Keys                           | Action                                                        |
+| ------------------------------ | ------------------------------------------------------------- |
+| `<leader>v`, `Ctrl+W k`        | Enter copy mode                                               |
+| `h`, `j`, `k`, `l`, arrow keys | Navigate                                                      |
+| `v`, `V`, `Ctrl+V`             | Start character-wise, line-wise, or block selection           |
+| `y`, `yy`                      | Yank to the vim register                                      |
 | `Enter`                        | Copy to the system clipboard or toggle expandable tool output |
-| `Y`                            | Yank to the vim register and scroll to the bottom       |
-| `Shift+Enter`                  | Copy to the system clipboard and scroll to the bottom   |
-| `Escape`                       | Exit visual mode                                        |
-| `q`                            | Exit copy mode and scroll to the bottom                 |
-| `Ctrl+W j`                     | Exit copy mode without scrolling                        |
-| `Ctrl+W w`                     | Toggle copy mode                                        |
-| `i`                            | Focus the prompt input in insert mode without scrolling |
-| `z`, `zt`, `zz`, `zb`          | Adjust copy-mode scroll positioning                     |
-| `H`, `M`, `L`                  | Jump to the top, middle, or bottom of the viewport      |
-| `/`, `?`                       | Search forward or backward in chat history              |
-| `n`, `N`                       | Repeat search in the same or opposite direction         |
+| `Y`                            | Yank to the vim register and scroll to the bottom             |
+| `Shift+Enter`                  | Copy to the system clipboard and scroll to the bottom         |
+| `Escape`                       | Exit visual mode                                              |
+| `q`                            | Exit copy mode and scroll to the bottom                       |
+| `Ctrl+W j`                     | Exit copy mode without scrolling                              |
+| `Ctrl+W w`                     | Toggle copy mode                                              |
+| `i`                            | Focus the prompt input in insert mode without scrolling       |
+| `z`, `zt`, `zz`, `zb`          | Adjust copy-mode scroll positioning                           |
+| `H`, `M`, `L`                  | Jump to the top, middle, or bottom of the viewport            |
+| `/`, `?`                       | Search forward or backward in chat history                    |
+| `n`, `N`                       | Repeat search in the same or opposite direction               |
 
 When in search mode, `Enter` submits the search, and `Escape` clears search highlights before exiting copy mode.
 
@@ -187,6 +187,16 @@ Use the system clipboard as Vim's register:
 ```
 
 Yank and delete operations sync to the system clipboard, `p` / `P` paste from it.
+
+### Modal dialog inputs
+
+Searchable dialog inputs use modal controls. Disable them with:
+
+```json
+{
+  "vim_modal_input": false
+}
+```
 
 > [!NOTE]
 > Terminal/OS clipboard shortcuts don’t preserve Vim linewise register state. External clipboard text is pasted as characterwise text.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Yank and delete operations sync to the system clipboard, `p` / `P` paste from it
 
 ### Modal dialog inputs
 
-Searchable dialog inputs use modal controls. Disable them with:
+Searchable dialog inputs and custom question answer inputs use modal controls. Disable them with:
 
 ```json
 {

--- a/packages/opencode/src/config/tui-migrate.ts
+++ b/packages/opencode/src/config/tui-migrate.ts
@@ -77,6 +77,7 @@ function normalizeTui(data: Record<string, unknown>):
       vim_enter_submit: boolean | undefined
       vim_insert_after_submit: boolean | undefined
       vim_system_clipboard_register: boolean | undefined
+      vim_modal_input: boolean | undefined
       vim_langmap: Record<string, string> | undefined
     }
   | undefined {
@@ -87,6 +88,7 @@ function normalizeTui(data: Record<string, unknown>):
     vim_enter_submit: Option.getOrUndefined(decodeBoolean(data.vim_enter_submit)),
     vim_insert_after_submit: Option.getOrUndefined(decodeBoolean(data.vim_insert_after_submit)),
     vim_system_clipboard_register: Option.getOrUndefined(decodeBoolean(data.vim_system_clipboard_register)),
+    vim_modal_input: Option.getOrUndefined(decodeBoolean(data.vim_modal_input)),
     vim_langmap: Option.getOrUndefined(decodeLangmap(data.vim_langmap)),
   }
   return parsed.scroll_speed === undefined &&
@@ -95,6 +97,7 @@ function normalizeTui(data: Record<string, unknown>):
     parsed.vim_enter_submit === undefined &&
     parsed.vim_insert_after_submit === undefined &&
     parsed.vim_system_clipboard_register === undefined &&
+    parsed.vim_modal_input === undefined &&
     parsed.vim_langmap === undefined
     ? undefined
     : parsed

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -126,7 +126,13 @@ it.instance("loads tui config with the same precedence order as server config pa
       yield* fs.writeWithDirs(
         path.join(test.directory, ".opencode", "tui.json"),
         JSON.stringify(
-          { theme: "local", diff_style: "stacked", vim_enter_submit: true, vim_insert_after_submit: true },
+          {
+            theme: "local",
+            diff_style: "stacked",
+            vim_enter_submit: true,
+            vim_insert_after_submit: true,
+            vim_modal_input: false,
+          },
           null,
           2,
         ),
@@ -137,6 +143,7 @@ it.instance("loads tui config with the same precedence order as server config pa
       expect(config.diff_style).toBe("stacked")
       expect(config.vim_enter_submit).toBe(true)
       expect(config.vim_insert_after_submit).toBe(true)
+      expect(config.vim_modal_input).toBe(false)
     }),
   ),
 )
@@ -147,7 +154,8 @@ it.instance("resolves attention config defaults and overrides", () =>
       const fs = yield* FSUtil.Service
       const test = yield* TestInstance
 
-      expect((yield* getTuiConfig(test.directory)).attention).toEqual({
+      const defaults = yield* getTuiConfig(test.directory)
+      expect(defaults.attention).toEqual({
         enabled: false,
         notifications: true,
         sound: true,
@@ -155,6 +163,7 @@ it.instance("resolves attention config defaults and overrides", () =>
         sound_pack: "opencode.default",
         sounds: {},
       })
+      expect(defaults.vim_modal_input).toBe(true)
 
       yield* fs.writeJson(path.join(test.directory, "tui.json"), {
         attention: {
@@ -197,7 +206,13 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       const source = path.join(test.directory, "opencode.json")
       yield* fs.writeJson(source, {
         theme: "migrated-theme",
-        tui: { scroll_speed: 5, vim_enter_submit: true, vim_insert_after_submit: true, vim_langmap: { д: "l" } },
+        tui: {
+          scroll_speed: 5,
+          vim_enter_submit: true,
+          vim_insert_after_submit: true,
+          vim_modal_input: false,
+          vim_langmap: { д: "l" },
+        },
         keybinds: { app_exit: "ctrl+q" },
       })
 
@@ -206,6 +221,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       expect(config.scroll_speed).toBe(5)
       expect(config.vim_enter_submit).toBe(true)
       expect(config.vim_insert_after_submit).toBe(true)
+      expect(config.vim_modal_input).toBe(false)
       expect(config.vim_langmap).toEqual({ д: "l" })
       expect(config.keybinds.get("app.exit")?.[0]?.key).toBe("ctrl+q")
       expect(JSON.parse(yield* fs.readFileString(path.join(test.directory, "tui.json")))).toMatchObject({
@@ -213,6 +229,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
         scroll_speed: 5,
         vim_enter_submit: true,
         vim_insert_after_submit: true,
+        vim_modal_input: false,
         vim_langmap: { д: "l" },
       })
       const server = JSON.parse(yield* fs.readFileString(source))

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -75,6 +75,9 @@ export const Info = Schema.Struct({
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
   vim: Schema.optional(Schema.Boolean).annotate({ description: "Enable vim-style input for the prompt" }),
+  vim_modal_input: Schema.optional(Schema.Boolean).annotate({
+    description: "Enable Vim-style modal controls for command palette and small dialog inputs",
+  }),
   prompt_max_height: Schema.optional(PromptMaxHeight),
   prompt_scrollbar: Schema.optional(Schema.Boolean).annotate({ description: "Show a scrollbar for the prompt input" }),
   vim_enter_submit: Schema.optional(Schema.Boolean).annotate({
@@ -141,6 +144,7 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
     }),
     leader_timeout: input.leader_timeout ?? LeaderTimeoutDefault,
     mouse: input.mouse ?? true,
+    vim_modal_input: input.vim_modal_input ?? true,
   }
 }
 

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -140,7 +140,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
 
   function enterAnswerNormalMode() {
     if (textarea && !textarea.isDestroyed) {
-      textarea.cursorOffset = Math.min(textarea.cursorOffset, Math.max(0, textarea.plainText.length - 1))
+      textarea.cursorOffset = normalAnswerCursor(textarea.plainText, textarea.cursorOffset)
     }
     setStore("inputMode", "normal")
   }
@@ -647,6 +647,11 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       </box>
     </box>
   )
+}
+
+function normalAnswerCursor(text: string, cursor: number) {
+  if (text.length === 0) return 0
+  return Math.max(0, Math.min(cursor - 1, text.length - 1))
 }
 
 function hasModifier(event: KeyEvent) {

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -662,7 +662,7 @@ function normalAnswerCursor(text: string, cursor: number) {
 }
 
 function hasModifier(event: KeyEvent) {
-  return !!event.ctrl || !!event.meta || !!event.super
+  return !!event.ctrl || !!event.meta || !!event.super || !!event.hyper || !!event.option
 }
 
 function answerKeyName(event: KeyEvent) {

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -21,6 +21,7 @@ import {
   type SingleLineVimKeyEvent,
 } from "../../ui/single-line-vim-motions"
 import type { ModalInputMode } from "../../ui/modal-input-controls"
+import { useVimEnabled } from "../../component/vim"
 
 const QUESTION_MODE = "question"
 
@@ -31,6 +32,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   const tuiConfig = useTuiConfig()
   const keymap = useOpencodeKeymap()
   const modeStack = useOpencodeModeStack()
+  const vimEnabled = useVimEnabled()
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -60,7 +62,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     if (!value) return false
     return store.answers[store.tab]?.includes(value) ?? false
   })
-  const modalInputEnabled = createMemo(() => tuiConfig.vim_modal_input)
+  const modalInputEnabled = createMemo(() => vimEnabled() && tuiConfig.vim_modal_input)
   const answerMotions = createSingleLineVimMotions({
     text: () => textarea?.plainText ?? "",
     cursor: () => textarea?.cursorOffset ?? 0,

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -158,6 +158,9 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     if (key === "escape") return false
     if (key === "i" || key === "a" || key === "/") {
       answerMotions.clearPending()
+      if (key === "a" && textarea && !textarea.isDestroyed) {
+        textarea.cursorOffset = Math.min(textarea.plainText.length, textarea.cursorOffset + 1)
+      }
       setStore("inputMode", "insert")
       textarea?.focus()
       event.preventDefault()

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -149,7 +149,10 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
 
   function handleAnswerKey(event: SingleLineVimKeyEvent) {
     if (!modalInputEnabled()) return false
-    if (hasModifier(event)) return false
+    if (hasModifier(event)) {
+      answerMotions.clearPending()
+      return false
+    }
     const key = answerKeyName(event)
     if (store.inputMode === "insert") {
       if (key !== "escape") return false
@@ -220,6 +223,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         title: "Clear answer edit",
         category: "Question",
         run() {
+          answerMotions.clearPending()
           const text = textarea?.plainText ?? ""
           if (!text) {
             setEditing(false)
@@ -259,6 +263,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         desc: "Submit answer edit",
         group: "Question",
         cmd: () => {
+          answerMotions.clearPending()
           const text = textarea?.plainText?.trim() ?? ""
           const prev = store.custom[store.tab]
 

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -164,10 +164,15 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     return false
   }
 
+  function setEditing(editing: boolean) {
+    answerMotions.clearPending()
+    setStore("editing", editing)
+  }
+
   function selectOption() {
     if (other()) {
       if (!multi()) {
-        setStore("editing", true)
+        setEditing(true)
         setStore("inputMode", "insert")
         return
       }
@@ -176,7 +181,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         toggle(value)
         return
       }
-      setStore("editing", true)
+      setEditing(true)
       setStore("inputMode", "insert")
       return
     }
@@ -205,7 +210,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         run() {
           const text = textarea?.plainText ?? ""
           if (!text) {
-            setStore("editing", false)
+            setEditing(false)
             return
           }
           textarea?.setText("")
@@ -232,7 +237,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                 if (text) {
                   setClearedText({ tab: store.tab, text })
                 }
-                setStore("editing", false)
+                setEditing(false)
               },
             },
           ]),
@@ -255,7 +260,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
               answers[store.tab] = (answers[store.tab] ?? []).filter((x) => x !== prev)
               setStore("answers", answers)
             }
-            setStore("editing", false)
+            setEditing(false)
             return
           }
 
@@ -274,12 +279,12 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
             const answers = [...store.answers]
             answers[store.tab] = next
             setStore("answers", answers)
-            setStore("editing", false)
+            setEditing(false)
             return
           }
 
           pick(text, true)
-          setStore("editing", false)
+          setEditing(false)
         },
       },
     ],
@@ -387,7 +392,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                   inputs[stash.tab] = stash.text
                   setStore("custom", inputs)
                   setClearedText()
-                  setStore("editing", true)
+                  setEditing(true)
                   setStore("inputMode", "insert")
                 },
               },

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -150,6 +150,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     }
     if (key === "escape") return false
     if (key === "i" || key === "a" || key === "/") {
+      answerMotions.clearPending()
       setStore("inputMode", "insert")
       textarea?.focus()
       event.preventDefault()

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -138,13 +138,20 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     setStore("selected", 0)
   }
 
+  function enterAnswerNormalMode() {
+    if (textarea && !textarea.isDestroyed) {
+      textarea.cursorOffset = Math.min(textarea.cursorOffset, Math.max(0, textarea.plainText.length - 1))
+    }
+    setStore("inputMode", "normal")
+  }
+
   function handleAnswerKey(event: SingleLineVimKeyEvent) {
     if (!modalInputEnabled()) return false
     if (hasModifier(event)) return false
     const key = answerKeyName(event)
     if (store.inputMode === "insert") {
       if (key !== "escape") return false
-      setStore("inputMode", "normal")
+      enterAnswerNormalMode()
       event.preventDefault()
       return true
     }
@@ -224,7 +231,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
               key: "escape",
               desc: "Enter normal mode",
               group: "Question",
-              cmd: () => setStore("inputMode", "normal"),
+              cmd: () => enterAnswerNormalMode(),
             },
           ]
         : [

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -1,7 +1,7 @@
 import { createStore } from "solid-js/store"
-import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
 import { useRenderer } from "@opentui/solid"
-import type { TextareaRenderable } from "@opentui/core"
+import type { KeyEvent, TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
@@ -14,6 +14,13 @@ import {
   useOpencodeKeymap,
   useOpencodeModeStack,
 } from "../../keymap"
+import {
+  createSingleLineVimMotions,
+  isSingleLineVimPrintableKey,
+  singleLineVimKeyName,
+  type SingleLineVimKeyEvent,
+} from "../../ui/single-line-vim-motions"
+import type { ModalInputMode } from "../../ui/modal-input-controls"
 
 const QUESTION_MODE = "question"
 
@@ -35,6 +42,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     custom: [] as string[],
     selected: 0,
     editing: false,
+    inputMode: "insert" as ModalInputMode,
   })
 
   let textarea: TextareaRenderable | undefined
@@ -51,6 +59,26 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     const value = input()
     if (!value) return false
     return store.answers[store.tab]?.includes(value) ?? false
+  })
+  const modalInputEnabled = createMemo(() => tuiConfig.vim_modal_input)
+  const answerMotions = createSingleLineVimMotions({
+    text: () => textarea?.plainText ?? "",
+    cursor: () => textarea?.cursorOffset ?? 0,
+    setCursor: (offset) => {
+      if (!textarea || textarea.isDestroyed) return
+      textarea.cursorOffset = offset
+    },
+    setText: (text) => {
+      if (!textarea || textarea.isDestroyed) return
+      textarea.setText(text)
+    },
+    enterInsert: () => setStore("inputMode", "insert"),
+    focus: () => textarea?.focus(),
+  })
+
+  createEffect(() => {
+    if (!textarea || textarea.isDestroyed) return
+    textarea.cursorStyle = modalInputEnabled() && store.inputMode === "normal" ? { style: "block", blinking: false } : { style: "line", blinking: true }
   })
 
   function submit() {
@@ -110,10 +138,36 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     setStore("selected", 0)
   }
 
+  function handleAnswerKey(event: SingleLineVimKeyEvent) {
+    if (!modalInputEnabled()) return false
+    if (hasModifier(event)) return false
+    const key = answerKeyName(event)
+    if (store.inputMode === "insert") {
+      if (key !== "escape") return false
+      setStore("inputMode", "normal")
+      event.preventDefault()
+      return true
+    }
+    if (key === "escape") return false
+    if (key === "i" || key === "a" || key === "/") {
+      setStore("inputMode", "insert")
+      textarea?.focus()
+      event.preventDefault()
+      return true
+    }
+    if (answerMotions.handleKey(event)) return true
+    if (isSingleLineVimPrintableKey(key) || key === "backspace" || key === "delete") {
+      event.preventDefault()
+      return true
+    }
+    return false
+  }
+
   function selectOption() {
     if (other()) {
       if (!multi()) {
         setStore("editing", true)
+        setStore("inputMode", "insert")
         return
       }
       const value = input()
@@ -122,6 +176,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         return
       }
       setStore("editing", true)
+      setStore("inputMode", "insert")
       return
     }
     const opt = options()[store.selected]
@@ -157,18 +212,29 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       },
     ],
     bindings: [
-      {
-        key: "escape",
-        desc: "Cancel answer edit",
-        group: "Question",
-        cmd: () => {
-          const text = textarea?.plainText ?? ""
-          if (text) {
-            setClearedText({ tab: store.tab, text })
-          }
-          setStore("editing", false)
-        },
-      },
+      ...(modalInputEnabled() && store.inputMode === "insert"
+        ? [
+            {
+              key: "escape",
+              desc: "Enter normal mode",
+              group: "Question",
+              cmd: () => setStore("inputMode", "normal"),
+            },
+          ]
+        : [
+            {
+              key: "escape",
+              desc: "Cancel answer edit",
+              group: "Question",
+              cmd: () => {
+                const text = textarea?.plainText ?? ""
+                if (text) {
+                  setClearedText({ tab: store.tab, text })
+                }
+                setStore("editing", false)
+              },
+            },
+          ]),
       ...tuiConfig.keybinds.get("prompt.clear"),
       {
         key: "return",
@@ -321,6 +387,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                   setStore("custom", inputs)
                   setClearedText()
                   setStore("editing", true)
+                  setStore("inputMode", "insert")
                 },
               },
               { key: "escape", desc: "Reject question", group: "Question", cmd: () => reject() },
@@ -486,6 +553,14 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                         textColor={theme.text}
                         focusedTextColor={theme.text}
                         cursorColor={theme.primary}
+                        cursorStyle={
+                          modalInputEnabled() && store.inputMode === "normal"
+                            ? { style: "block", blinking: false }
+                            : { style: "line", blinking: true }
+                        }
+                        onKeyDown={(event: SingleLineVimKeyEvent) => {
+                          if (handleAnswerKey(event)) return
+                        }}
                       />
                     </box>
                   </Show>
@@ -556,4 +631,13 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       </box>
     </box>
   )
+}
+
+function hasModifier(event: KeyEvent) {
+  return !!event.ctrl || !!event.meta || !!event.super
+}
+
+function answerKeyName(event: KeyEvent) {
+  if (event.name === "escape") return "escape"
+  return singleLineVimKeyName(event)
 }

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -157,7 +157,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   function enterNormalMode() {
     if (input && !input.isDestroyed) {
-      input.cursorOffset = Math.min(input.cursorOffset, Math.max(0, input.plainText.length - 1))
+      input.cursorOffset = normalCursor(input.plainText, input.cursorOffset)
     }
     setStore("inputMode", "normal")
   }
@@ -792,6 +792,11 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       </Show>
     </box>
   )
+}
+
+function normalCursor(text: string, cursor: number) {
+  if (text.length === 0) return 0
+  return Math.max(0, Math.min(cursor - 1, text.length - 1))
 }
 
 function Option(props: {

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -155,6 +155,13 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     input.cursorStyle = modalInputEnabled() && store.inputMode === "normal" ? { style: "block", blinking: false } : { style: "line", blinking: true }
   })
 
+  function enterNormalMode() {
+    if (input && !input.isDestroyed) {
+      input.cursorOffset = Math.min(input.cursorOffset, Math.max(0, input.plainText.length - 1))
+    }
+    setStore("inputMode", "normal")
+  }
+
   const actions = createMemo(() => props.actions ?? [])
   const shownActions = createMemo(() => actions().filter((item) => !item.hidden))
   const actionBindings = useKeymapSelector((keymap) =>
@@ -505,7 +512,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                 key: "escape",
                 desc: "Enter normal mode",
                 group: "Dialog",
-                cmd: () => setStore("inputMode", "normal"),
+                cmd: () => enterNormalMode(),
               },
             ]
           : []),

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -20,6 +20,7 @@ import { Locale } from "../util/locale"
 import { getScrollAcceleration } from "../util/scroll"
 import { useTuiConfig } from "../config"
 import { formatKeyBindings, useBindings, useKeymapSelector } from "../keymap"
+import { useVimEnabled } from "../component/vim"
 
 export interface DialogSelectProps<T> {
   title: string
@@ -87,6 +88,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const dialog = useDialog()
   const { theme } = useTheme()
   const tuiConfig = useTuiConfig()
+  const vimEnabled = useVimEnabled()
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
 
   const [store, setStore] = createStore({
@@ -97,7 +99,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   })
   const [focusedAction, setFocusedAction] = createSignal<number>()
   const actionFocused = createMemo(() => focusedAction() !== undefined)
-  const modalInputEnabled = createMemo(() => props.renderFilter !== false && (props.modalInput ?? tuiConfig.vim_modal_input))
+  const modalInputEnabled = createMemo(() => vimEnabled() && props.renderFilter !== false && (props.modalInput ?? tuiConfig.vim_modal_input))
   let selection: { value: T; category?: string } | undefined
   let resetSelection = false
   let visibilityGeneration = 0

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -344,6 +344,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   }
 
   function moveTo(next: number, center = false, preserve = true) {
+    if (next < 0) return
     setFocusedAction(undefined)
     setStore("selected", next)
     const option = selected()

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -15,6 +15,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import * as fuzzysort from "fuzzysort"
 import { isDeepEqual } from "remeda"
 import { useDialog, type DialogContext } from "./dialog"
+import { createModalInputControls, type ModalInputKeyEvent, type ModalInputMode } from "./modal-input-controls"
 import { Locale } from "../util/locale"
 import { getScrollAcceleration } from "../util/scroll"
 import { useTuiConfig } from "../config"
@@ -36,6 +37,7 @@ export interface DialogSelectProps<T> {
   renderFilter?: boolean
   locked?: boolean
   preserveSelection?: boolean
+  modalInput?: boolean
   actions?: {
     command: string
     title: string
@@ -91,9 +93,11 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     selected: 0,
     filter: "",
     input: "keyboard" as "keyboard" | "mouse",
+    inputMode: "insert" as ModalInputMode,
   })
   const [focusedAction, setFocusedAction] = createSignal<number>()
   const actionFocused = createMemo(() => focusedAction() !== undefined)
+  const modalInputEnabled = createMemo(() => props.renderFilter !== false && (props.modalInput ?? tuiConfig.vim_modal_input))
   let selection: { value: T; category?: string } | undefined
   let resetSelection = false
   let visibilityGeneration = 0
@@ -114,6 +118,42 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   )
 
   let input: InputRenderable
+  const modalInput = createModalInputControls({
+    mode: () => store.inputMode,
+    setMode: (mode) => setStore("inputMode", mode),
+    move: (direction) => {
+      setStore("input", "keyboard")
+      move(direction)
+    },
+    moveToStart: () => {
+      if (props.locked) return
+      setStore("input", "keyboard")
+      moveTo(0)
+    },
+    moveToEnd: () => {
+      if (props.locked) return
+      setStore("input", "keyboard")
+      moveTo(flat().length - 1)
+    },
+    focus: () => input?.focus(),
+    text: () => input?.plainText ?? "",
+    cursor: () => input?.cursorOffset ?? 0,
+    setCursor: (offset) => {
+      if (!input || input.isDestroyed) return
+      input.cursorOffset = offset
+    },
+    setText: (text) => {
+      if (!input || input.isDestroyed) return
+      input.setText(text)
+      setStore("filter", text)
+      props.onFilter?.(text)
+    },
+  })
+
+  createEffect(() => {
+    if (!input || input.isDestroyed) return
+    input.cursorStyle = modalInputEnabled() && store.inputMode === "normal" ? { style: "block", blinking: false } : { style: "line", blinking: true }
+  })
 
   const actions = createMemo(() => props.actions ?? [])
   const shownActions = createMemo(() => actions().filter((item) => !item.hidden))
@@ -370,6 +410,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     const visible = shownActions()
 
     return {
+      priority: modalInputEnabled() ? 1 : undefined,
       commands: [
         {
           name: "dialog.select.prev",
@@ -458,6 +499,16 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           "dialog.select.submit",
         ]),
         ...visible.flatMap((item) => tuiConfig.keybinds.get(item.command)),
+        ...(modalInputEnabled() && store.inputMode === "insert"
+          ? [
+              {
+                key: "escape",
+                desc: "Enter normal mode",
+                group: "Dialog",
+                cmd: () => setStore("inputMode", "normal"),
+              },
+            ]
+          : []),
         ...(visible.length
           ? [
               {
@@ -568,8 +619,9 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           </text>
         </box>
         <Show when={props.renderFilter !== false}>
-          <box paddingTop={1}>
+          <box paddingTop={1} flexDirection="row" gap={1}>
             <input
+              flexGrow={1}
               onInput={(e) => {
                 if (props.locked) return
                 batch(() => {
@@ -577,9 +629,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                   props.onFilter?.(e)
                 })
               }}
+              onKeyDown={(event: ModalInputKeyEvent) => {
+                if (modalInputEnabled() && modalInput.handleKey(event)) return
+              }}
               focusedBackgroundColor={theme.backgroundPanel}
               cursorColor={theme.primary}
-              cursorStyle={{ style: "line", blinking: true }}
+              cursorStyle={
+                modalInputEnabled() && store.inputMode === "normal" ? { style: "block", blinking: false } : { style: "line", blinking: true }
+              }
               focusedTextColor={theme.textMuted}
               ref={(r) => {
                 input = r

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -158,10 +158,15 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   })
 
   function enterNormalMode() {
+    modalInput.clearPending()
     if (input && !input.isDestroyed) {
       input.cursorOffset = normalCursor(input.plainText, input.cursorOffset)
     }
     setStore("inputMode", "normal")
+  }
+
+  function clearModalInputPending() {
+    if (modalInputEnabled()) modalInput.clearPending()
   }
 
   const actions = createMemo(() => props.actions ?? [])
@@ -337,6 +342,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   )
 
   function move(direction: number) {
+    clearModalInputPending()
     if (props.locked) return
     if (flat().length === 0) return
     let next = store.selected + direction
@@ -346,6 +352,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   }
 
   function moveTo(next: number, center = false, preserve = true) {
+    clearModalInputPending()
     if (next < 0) return
     setFocusedAction(undefined)
     setStore("selected", next)
@@ -392,6 +399,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   }
 
   function submit() {
+    clearModalInputPending()
     if (props.locked) return
     setStore("input", "keyboard")
     const index = focusedAction()
@@ -406,6 +414,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   }
 
   function moveAction(direction: 1 | -1) {
+    clearModalInputPending()
     if (props.locked) return
     const total = actionItems().length
     if (total === 0) return
@@ -489,6 +498,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           title: item.title,
           category: "Dialog",
           run() {
+            clearModalInputPending()
             if (props.locked) return
             if (isActionDisabled(item)) return
             setStore("input", "keyboard")
@@ -562,6 +572,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const right = createMemo(() => visibleActions().filter((item) => item.side === "right"))
 
   function triggerAction(item: VisibleAction | undefined) {
+    clearModalInputPending()
     if (props.locked) return
     if (!item || !isActionItem(item) || isActionDisabled(item)) return
     setStore("input", "keyboard")

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -43,6 +43,7 @@ export function createModalInputControls(input: {
       if (input.mode() === "insert") {
         if (key !== "escape") return false
         pending = ""
+        input.setCursor(Math.min(input.cursor(), Math.max(0, input.text().length - 1)))
         input.setMode("normal")
         event.preventDefault()
         return true

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -51,6 +51,7 @@ export function createModalInputControls(input: {
       if (key === "escape") return false
       if (key === "i" || key === "a" || key === "/") {
         pending = ""
+        motions.clearPending()
         input.setMode("insert")
         input.focus()
         event.preventDefault()

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -53,6 +53,7 @@ export function createModalInputControls(input: {
       if (key === "i" || key === "a" || key === "/") {
         pending = ""
         motions.clearPending()
+        if (key === "a") input.setCursor(Math.min(input.text().length, input.cursor() + 1))
         input.setMode("insert")
         input.focus()
         event.preventDefault()

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -1,0 +1,111 @@
+import type { KeyEvent } from "@opentui/core"
+import {
+  createSingleLineVimMotions,
+  isSingleLineVimPrintableKey,
+  singleLineVimKeyName,
+  type SingleLineVimKeyEvent,
+} from "./single-line-vim-motions"
+
+export type ModalInputMode = "insert" | "normal"
+
+export type ModalInputKeyEvent = SingleLineVimKeyEvent
+
+export function createModalInputControls(input: {
+  mode: () => ModalInputMode
+  setMode: (mode: ModalInputMode) => void
+  move: (direction: 1 | -1) => void
+  moveToStart: () => void
+  moveToEnd: () => void
+  focus: () => void
+  text: () => string
+  cursor: () => number
+  setCursor: (offset: number) => void
+  setText: (text: string) => void
+}) {
+  let pending = ""
+  const motions = createSingleLineVimMotions({
+    text: input.text,
+    cursor: input.cursor,
+    setCursor: input.setCursor,
+    setText: input.setText,
+    enterInsert: () => input.setMode("insert"),
+    focus: input.focus,
+  })
+
+  return {
+    handleKey(event: ModalInputKeyEvent) {
+      if (hasModifier(event)) {
+        pending = ""
+        motions.handleKey(event)
+        return false
+      }
+      const key = keyName(event)
+      if (input.mode() === "insert") {
+        if (key !== "escape") return false
+        pending = ""
+        input.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "escape") return false
+      if (key === "i" || key === "a" || key === "/") {
+        pending = ""
+        input.setMode("insert")
+        input.focus()
+        event.preventDefault()
+        return true
+      }
+      if (motions.handleKey(event)) {
+        pending = ""
+        return true
+      }
+      if (key === "j") {
+        pending = ""
+        input.move(1)
+        event.preventDefault()
+        return true
+      }
+      if (key === "k") {
+        pending = ""
+        input.move(-1)
+        event.preventDefault()
+        return true
+      }
+      if (key === "G") {
+        pending = ""
+        input.moveToEnd()
+        event.preventDefault()
+        return true
+      }
+      if (key === "g") {
+        if (pending === "g") {
+          pending = ""
+          input.moveToStart()
+          event.preventDefault()
+          return true
+        }
+        pending = "g"
+        event.preventDefault()
+        return true
+      }
+
+      pending = ""
+      if (isSingleLineVimPrintableKey(key) || key === "backspace" || key === "delete") {
+        event.preventDefault()
+        return true
+      }
+      return false
+    },
+  }
+}
+
+function hasModifier(event: KeyEvent) {
+  return !!event.ctrl || !!event.meta || !!event.super
+}
+
+function keyName(event: KeyEvent) {
+  if (event.name === "escape") return "escape"
+  if (event.shift && event.name === "g") return "G"
+  return singleLineVimKeyName(event)
+}

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -43,7 +43,7 @@ export function createModalInputControls(input: {
       if (input.mode() === "insert") {
         if (key !== "escape") return false
         pending = ""
-        input.setCursor(Math.min(input.cursor(), Math.max(0, input.text().length - 1)))
+        input.setCursor(normalCursor(input.text(), input.cursor()))
         input.setMode("normal")
         event.preventDefault()
         return true
@@ -105,6 +105,11 @@ export function createModalInputControls(input: {
 
 function hasModifier(event: KeyEvent) {
   return !!event.ctrl || !!event.meta || !!event.super
+}
+
+function normalCursor(text: string, cursor: number) {
+  if (text.length === 0) return 0
+  return Math.max(0, Math.min(cursor - 1, text.length - 1))
 }
 
 function keyName(event: KeyEvent) {

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -33,6 +33,10 @@ export function createModalInputControls(input: {
   })
 
   return {
+    clearPending() {
+      pending = ""
+      motions.clearPending()
+    },
     handleKey(event: ModalInputKeyEvent) {
       if (hasModifier(event)) {
         pending = ""

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -108,7 +108,7 @@ export function createModalInputControls(input: {
 }
 
 function hasModifier(event: KeyEvent) {
-  return !!event.ctrl || !!event.meta || !!event.super
+  return !!event.ctrl || !!event.meta || !!event.super || !!event.hyper || !!event.option
 }
 
 function normalCursor(text: string, cursor: number) {

--- a/packages/tui/src/ui/single-line-vim-motions.ts
+++ b/packages/tui/src/ui/single-line-vim-motions.ts
@@ -16,6 +16,9 @@ export function createSingleLineVimMotions(input: {
   let pending = ""
 
   return {
+    clearPending() {
+      pending = ""
+    },
     handleKey(event: SingleLineVimKeyEvent) {
       if (hasModifier(event)) {
         pending = ""

--- a/packages/tui/src/ui/single-line-vim-motions.ts
+++ b/packages/tui/src/ui/single-line-vim-motions.ts
@@ -1,0 +1,138 @@
+import type { KeyEvent } from "@opentui/core"
+
+export type SingleLineVimKeyEvent = KeyEvent & {
+  preventDefault(): void
+  defaultPrevented?: boolean
+}
+
+export function createSingleLineVimMotions(input: {
+  text: () => string
+  cursor: () => number
+  setCursor: (offset: number) => void
+  setText: (text: string) => void
+  enterInsert: () => void
+  focus: () => void
+}) {
+  let pending = ""
+
+  return {
+    handleKey(event: SingleLineVimKeyEvent) {
+      if (hasModifier(event)) {
+        pending = ""
+        return false
+      }
+      const key = singleLineVimKeyName(event)
+      if (key === "d") {
+        if (pending === "d") {
+          pending = ""
+          input.setText("")
+          input.setCursor(0)
+          event.preventDefault()
+          return true
+        }
+        pending = "d"
+        event.preventDefault()
+        return true
+      }
+
+      pending = ""
+      if (key === "h") {
+        input.setCursor(Math.max(0, input.cursor() - 1))
+        event.preventDefault()
+        return true
+      }
+      if (key === "l") {
+        input.setCursor(Math.min(normalCursorEnd(input.text()), input.cursor() + 1))
+        event.preventDefault()
+        return true
+      }
+      if (key === "b") {
+        input.setCursor(previousWordStart(input.text(), input.cursor()))
+        event.preventDefault()
+        return true
+      }
+      if (key === "w") {
+        input.setCursor(nextWordStart(input.text(), input.cursor()))
+        event.preventDefault()
+        return true
+      }
+      if (key === "e") {
+        input.setCursor(nextWordEnd(input.text(), input.cursor()))
+        event.preventDefault()
+        return true
+      }
+      if (key === "0") {
+        input.setCursor(0)
+        event.preventDefault()
+        return true
+      }
+      if (key === "$") {
+        input.setCursor(normalCursorEnd(input.text()))
+        event.preventDefault()
+        return true
+      }
+      if (key === "I") {
+        input.setCursor(0)
+        input.enterInsert()
+        input.focus()
+        event.preventDefault()
+        return true
+      }
+      if (key === "A") {
+        input.setCursor(input.text().length)
+        input.enterInsert()
+        input.focus()
+        event.preventDefault()
+        return true
+      }
+      return false
+    },
+  }
+}
+
+export function singleLineVimKeyName(event: KeyEvent) {
+  if (event.name === "backspace" || event.sequence === "\b" || event.sequence === "\x7f" || event.raw === "\b" || event.raw === "\x7f") return "backspace"
+  if (event.name === "delete") return "delete"
+  if (event.name === "slash" || event.sequence === "/" || event.raw === "/") return "/"
+  const text = event.sequence?.length === 1 ? event.sequence : event.raw?.length === 1 ? event.raw : undefined
+  if (text) return text
+  if (event.shift && event.name === "i") return "I"
+  if (event.shift && event.name === "a") return "A"
+  if (event.shift && event.name === "4") return "$"
+  return event.name ?? ""
+}
+
+export function isSingleLineVimPrintableKey(key: string) {
+  return key.length === 1 || key === "space"
+}
+
+function hasModifier(event: KeyEvent) {
+  return !!event.ctrl || !!event.meta || !!event.super
+}
+
+function normalCursorEnd(text: string) {
+  return Math.max(0, text.length - 1)
+}
+
+function previousWordStart(text: string, cursor: number) {
+  const before = text.slice(0, Math.max(0, cursor))
+  const match = before.match(/\S+\s*$/)
+  return match ? before.length - match[0].length : 0
+}
+
+function nextWordStart(text: string, cursor: number) {
+  const end = normalCursorEnd(text)
+  const start = Math.min(text.length, cursor)
+  const wordEnd = text[start] && /\S/.test(text[start]) ? text.slice(start).search(/\s/) : 0
+  const afterWord = wordEnd === -1 ? text.length : start + wordEnd
+  const match = text.slice(afterWord).match(/\S/)
+  return match?.index === undefined ? end : Math.min(end, afterWord + match.index)
+}
+
+function nextWordEnd(text: string, cursor: number) {
+  const end = normalCursorEnd(text)
+  const start = Math.min(text.length, cursor)
+  const next = text[start] && /\S/.test(text[start]) ? start + 1 : start
+  const word = text.slice(next).match(/\S+/)
+  return word?.index === undefined ? end : Math.min(end, next + word.index + word[0].length - 1)
+}

--- a/packages/tui/src/ui/single-line-vim-motions.ts
+++ b/packages/tui/src/ui/single-line-vim-motions.ts
@@ -110,7 +110,7 @@ export function isSingleLineVimPrintableKey(key: string) {
 }
 
 function hasModifier(event: KeyEvent) {
-  return !!event.ctrl || !!event.meta || !!event.super
+  return !!event.ctrl || !!event.meta || !!event.super || !!event.hyper || !!event.option
 }
 
 function normalCursorEnd(text: string) {

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -71,6 +71,15 @@ describe("modal input controls", () => {
     expect(state.text()).toBe("alpha")
   })
 
+  test("clamps insert cursor when entering normal mode", () => {
+    const state = createControls({ mode: "insert", text: "alpha", cursor: 5 })
+
+    state.controls.handleKey(key("escape"))
+
+    expect(state.mode()).toBe("normal")
+    expect(state.cursor()).toBe(4)
+  })
+
   test("clears pending picker motions before passing ctrl bindings to the outer keymap", () => {
     const state = createControls()
 

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -117,6 +117,19 @@ describe("modal input controls", () => {
     expect(state.cursor()).toBe(15)
   })
 
+  test("supports i and a insert motions", () => {
+    const insert = createControls({ text: "alpha", cursor: 2 })
+
+    insert.controls.handleKey(key("i"))
+    expect(insert.cursor()).toBe(2)
+    expect(insert.mode()).toBe("insert")
+
+    const append = createControls({ text: "alpha", cursor: 2 })
+    append.controls.handleKey(key("a"))
+    expect(append.cursor()).toBe(3)
+    expect(append.mode()).toBe("insert")
+  })
+
   test("supports I and A insert motions", () => {
     const state = createControls({ text: "alpha", cursor: 2 })
 

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "bun:test"
 import { createModalInputControls, type ModalInputKeyEvent, type ModalInputMode } from "../src/ui/modal-input-controls"
 
-function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: boolean }) {
+function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: boolean; option?: boolean; hyper?: boolean }) {
   let prevented = false
   return {
     name,
     sequence: input?.sequence,
     shift: input?.shift,
     ctrl: input?.ctrl,
+    option: input?.option,
+    hyper: input?.hyper,
     preventDefault() {
       prevented = true
     },
@@ -52,12 +54,14 @@ describe("modal input controls", () => {
     expect(state.moves).toEqual([1, -1])
   })
 
-  test("keeps ctrl bindings available for the outer keymap", () => {
+  test("keeps modified bindings available for the outer keymap", () => {
     const state = createControls()
-    const event = key("n", { ctrl: true })
+    const events = [key("n", { ctrl: true }), key("n", { option: true }), key("n", { hyper: true })]
 
-    expect(state.controls.handleKey(event)).toBe(false)
-    expect(event.defaultPrevented).toBe(false)
+    for (const event of events) {
+      expect(state.controls.handleKey(event)).toBe(false)
+      expect(event.defaultPrevented).toBe(false)
+    }
   })
 
   test("clears pending text motions before entering insert mode", () => {

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import { createModalInputControls, type ModalInputKeyEvent, type ModalInputMode } from "../src/ui/modal-input-controls"
+
+function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: boolean }) {
+  let prevented = false
+  return {
+    name,
+    sequence: input?.sequence,
+    shift: input?.shift,
+    ctrl: input?.ctrl,
+    preventDefault() {
+      prevented = true
+    },
+    get defaultPrevented() {
+      return prevented
+    },
+  } as ModalInputKeyEvent
+}
+
+function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?: number }) {
+  let mode = input?.mode ?? "normal"
+  let cursor = input?.cursor ?? 0
+  const moves: number[] = []
+  const controls = createModalInputControls({
+    mode: () => mode,
+    setMode: (next) => (mode = next),
+    move: (direction) => moves.push(direction),
+    moveToStart: () => moves.push(-100),
+    moveToEnd: () => moves.push(100),
+    focus() {},
+    text: () => input?.text ?? "",
+    cursor: () => cursor,
+    setCursor: (next) => (cursor = next),
+    setText() {},
+  })
+
+  return { controls, moves, mode: () => mode, cursor: () => cursor }
+}
+
+describe("modal input controls", () => {
+  test("uses escape to enter normal mode and j/k to move selection", () => {
+    const state = createControls({ mode: "insert" })
+
+    const escape = key("escape")
+    expect(state.controls.handleKey(escape)).toBe(true)
+    expect(escape.defaultPrevented).toBe(true)
+    expect(state.mode()).toBe("normal")
+
+    state.controls.handleKey(key("j"))
+    state.controls.handleKey(key("k"))
+    expect(state.moves).toEqual([1, -1])
+  })
+
+  test("keeps ctrl bindings available for the outer keymap", () => {
+    const state = createControls()
+    const event = key("n", { ctrl: true })
+
+    expect(state.controls.handleKey(event)).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test("clears pending picker motions before passing ctrl bindings to the outer keymap", () => {
+    const state = createControls()
+
+    state.controls.handleKey(key("g"))
+    state.controls.handleKey(key("n", { ctrl: true }))
+    state.controls.handleKey(key("g"))
+    expect(state.moves).toEqual([])
+  })
+
+  test("supports gg and G jumps", () => {
+    const state = createControls()
+
+    state.controls.handleKey(key("g"))
+    state.controls.handleKey(key("g"))
+    state.controls.handleKey(key("g", { sequence: "G", shift: true }))
+    expect(state.moves).toEqual([-100, 100])
+  })
+
+  test("supports basic cursor motions", () => {
+    const state = createControls({ text: "alpha beta gamma", cursor: 6 })
+
+    state.controls.handleKey(key("h"))
+    expect(state.cursor()).toBe(5)
+    state.controls.handleKey(key("l"))
+    expect(state.cursor()).toBe(6)
+    state.controls.handleKey(key("w"))
+    expect(state.cursor()).toBe(11)
+    state.controls.handleKey(key("b"))
+    expect(state.cursor()).toBe(6)
+    state.controls.handleKey(key("e"))
+    expect(state.cursor()).toBe(9)
+    state.controls.handleKey(key("0"))
+    expect(state.cursor()).toBe(0)
+    state.controls.handleKey(key("4", { sequence: "$", shift: true }))
+    expect(state.cursor()).toBe(15)
+  })
+
+  test("supports I and A insert motions", () => {
+    const state = createControls({ text: "alpha", cursor: 2 })
+
+    state.controls.handleKey(key("i", { sequence: "I", shift: true }))
+    expect(state.cursor()).toBe(0)
+    expect(state.mode()).toBe("insert")
+
+    const next = createControls({ text: "alpha", cursor: 2 })
+    next.controls.handleKey(key("a", { sequence: "A", shift: true }))
+    expect(next.cursor()).toBe(5)
+    expect(next.mode()).toBe("insert")
+  })
+})

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -19,6 +19,7 @@ function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: 
 
 function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?: number }) {
   let mode = input?.mode ?? "normal"
+  let text = input?.text ?? ""
   let cursor = input?.cursor ?? 0
   const moves: number[] = []
   const controls = createModalInputControls({
@@ -28,13 +29,13 @@ function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?:
     moveToStart: () => moves.push(-100),
     moveToEnd: () => moves.push(100),
     focus() {},
-    text: () => input?.text ?? "",
+    text: () => text,
     cursor: () => cursor,
     setCursor: (next) => (cursor = next),
-    setText() {},
+    setText: (next) => (text = next),
   })
 
-  return { controls, moves, mode: () => mode, cursor: () => cursor }
+  return { controls, moves, mode: () => mode, cursor: () => cursor, text: () => text }
 }
 
 describe("modal input controls", () => {
@@ -57,6 +58,17 @@ describe("modal input controls", () => {
 
     expect(state.controls.handleKey(event)).toBe(false)
     expect(event.defaultPrevented).toBe(false)
+  })
+
+  test("clears pending text motions before entering insert mode", () => {
+    const state = createControls({ text: "alpha", cursor: 2 })
+
+    state.controls.handleKey(key("d"))
+    state.controls.handleKey(key("i"))
+    state.controls.handleKey(key("escape"))
+    state.controls.handleKey(key("d"))
+
+    expect(state.text()).toBe("alpha")
   })
 
   test("clears pending picker motions before passing ctrl bindings to the outer keymap", () => {

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -96,6 +96,20 @@ describe("modal input controls", () => {
     expect(state.moves).toEqual([])
   })
 
+  test("lets outer keymap commands clear pending motions", () => {
+    const state = createControls({ text: "alpha", cursor: 2 })
+
+    state.controls.handleKey(key("g"))
+    state.controls.clearPending()
+    state.controls.handleKey(key("g"))
+    expect(state.moves).toEqual([])
+
+    state.controls.handleKey(key("d"))
+    state.controls.clearPending()
+    state.controls.handleKey(key("d"))
+    expect(state.text()).toBe("alpha")
+  })
+
   test("supports gg and G jumps", () => {
     const state = createControls()
 

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -71,13 +71,20 @@ describe("modal input controls", () => {
     expect(state.text()).toBe("alpha")
   })
 
-  test("clamps insert cursor when entering normal mode", () => {
+  test("normalizes insert cursor when entering normal mode", () => {
     const state = createControls({ mode: "insert", text: "alpha", cursor: 5 })
 
     state.controls.handleKey(key("escape"))
 
     expect(state.mode()).toBe("normal")
     expect(state.cursor()).toBe(4)
+
+    const middle = createControls({ mode: "insert", text: "alpha", cursor: 2 })
+
+    middle.controls.handleKey(key("escape"))
+
+    expect(middle.mode()).toBe("normal")
+    expect(middle.cursor()).toBe(1)
   })
 
   test("clears pending picker motions before passing ctrl bindings to the outer keymap", () => {

--- a/packages/tui/test/single-line-vim-motions.test.ts
+++ b/packages/tui/test/single-line-vim-motions.test.ts
@@ -76,6 +76,15 @@ describe("single line vim motions", () => {
     expect(state.cursor()).toBe(0)
   })
 
+  test("clears pending operators explicitly", () => {
+    const state = createMotions({ text: "alpha", cursor: 2 })
+
+    state.motions.handleKey(key("d"))
+    state.motions.clearPending()
+    state.motions.handleKey(key("d"))
+    expect(state.text()).toBe("alpha")
+  })
+
   test("ignores modified keys and clears pending operators", () => {
     const state = createMotions({ text: "alpha", cursor: 2 })
     const event = key("w", { ctrl: true })

--- a/packages/tui/test/single-line-vim-motions.test.ts
+++ b/packages/tui/test/single-line-vim-motions.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "bun:test"
 import { createSingleLineVimMotions, type SingleLineVimKeyEvent } from "../src/ui/single-line-vim-motions"
 
-function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: boolean }) {
+function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: boolean; option?: boolean; hyper?: boolean }) {
   let prevented = false
   return {
     name,
     sequence: input?.sequence,
     shift: input?.shift,
     ctrl: input?.ctrl,
+    option: input?.option,
+    hyper: input?.hyper,
     preventDefault() {
       prevented = true
     },
@@ -86,14 +88,16 @@ describe("single line vim motions", () => {
   })
 
   test("ignores modified keys and clears pending operators", () => {
-    const state = createMotions({ text: "alpha", cursor: 2 })
-    const event = key("w", { ctrl: true })
+    const events = [key("w", { ctrl: true }), key("w", { option: true }), key("w", { hyper: true })]
 
-    state.motions.handleKey(key("d"))
-    expect(state.motions.handleKey(event)).toBe(false)
-    expect(event.defaultPrevented).toBe(false)
-    expect(state.cursor()).toBe(2)
-    state.motions.handleKey(key("d"))
-    expect(state.text()).toBe("alpha")
+    for (const event of events) {
+      const state = createMotions({ text: "alpha", cursor: 2 })
+      state.motions.handleKey(key("d"))
+      expect(state.motions.handleKey(event)).toBe(false)
+      expect(event.defaultPrevented).toBe(false)
+      expect(state.cursor()).toBe(2)
+      state.motions.handleKey(key("d"))
+      expect(state.text()).toBe("alpha")
+    }
   })
 })

--- a/packages/tui/test/single-line-vim-motions.test.ts
+++ b/packages/tui/test/single-line-vim-motions.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { createSingleLineVimMotions, type SingleLineVimKeyEvent } from "../src/ui/single-line-vim-motions"
+
+function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: boolean }) {
+  let prevented = false
+  return {
+    name,
+    sequence: input?.sequence,
+    shift: input?.shift,
+    ctrl: input?.ctrl,
+    preventDefault() {
+      prevented = true
+    },
+    get defaultPrevented() {
+      return prevented
+    },
+  } as SingleLineVimKeyEvent
+}
+
+function createMotions(input: { text?: string; cursor?: number } = {}) {
+  let text = input.text ?? ""
+  let cursor = input.cursor ?? 0
+  let insert = false
+  const motions = createSingleLineVimMotions({
+    text: () => text,
+    cursor: () => cursor,
+    setCursor: (next) => (cursor = next),
+    setText: (next) => (text = next),
+    enterInsert: () => (insert = true),
+    focus() {},
+  })
+
+  return { motions, cursor: () => cursor, insert: () => insert, text: () => text }
+}
+
+describe("single line vim motions", () => {
+  test("moves by character, word, and line", () => {
+    const state = createMotions({ text: "alpha beta gamma", cursor: 6 })
+
+    state.motions.handleKey(key("h"))
+    expect(state.cursor()).toBe(5)
+    state.motions.handleKey(key("l"))
+    expect(state.cursor()).toBe(6)
+    state.motions.handleKey(key("w"))
+    expect(state.cursor()).toBe(11)
+    state.motions.handleKey(key("b"))
+    expect(state.cursor()).toBe(6)
+    state.motions.handleKey(key("e"))
+    expect(state.cursor()).toBe(9)
+    state.motions.handleKey(key("0"))
+    expect(state.cursor()).toBe(0)
+    state.motions.handleKey(key("4", { sequence: "$", shift: true }))
+    expect(state.cursor()).toBe(15)
+  })
+
+  test("enters insert at start and end", () => {
+    const start = createMotions({ text: "alpha", cursor: 2 })
+    start.motions.handleKey(key("i", { sequence: "I", shift: true }))
+    expect(start.cursor()).toBe(0)
+    expect(start.insert()).toBe(true)
+
+    const end = createMotions({ text: "alpha", cursor: 2 })
+    end.motions.handleKey(key("a", { sequence: "A", shift: true }))
+    expect(end.cursor()).toBe(5)
+    expect(end.insert()).toBe(true)
+  })
+
+  test("clears the line with dd", () => {
+    const state = createMotions({ text: "alpha", cursor: 2 })
+
+    state.motions.handleKey(key("d"))
+    expect(state.text()).toBe("alpha")
+    expect(state.cursor()).toBe(2)
+    state.motions.handleKey(key("d"))
+    expect(state.text()).toBe("")
+    expect(state.cursor()).toBe(0)
+  })
+
+  test("ignores modified keys and clears pending operators", () => {
+    const state = createMotions({ text: "alpha", cursor: 2 })
+    const event = key("w", { ctrl: true })
+
+    state.motions.handleKey(key("d"))
+    expect(state.motions.handleKey(event)).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+    expect(state.cursor()).toBe(2)
+    state.motions.handleKey(key("d"))
+    expect(state.text()).toBe("alpha")
+  })
+})


### PR DESCRIPTION
Adds vim modal controls to dialog inputs, including searchable pickers and custom question answers.

 - Esc enters normal mode
 - j/k move selection in normal mode
 - Supports single line motions: `h`/`j`/`k`/`l`, `w`/`b`/`e`, `0`/`$`, `I`/`A`, `dd`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Vim-style modal input (insert/normal) for the command palette and dialog/question text/filter fields, with motion-based navigation and mode-dependent cursor behavior.
* **Bug Fixes**
  * Enhanced TUI config migration and defaults: supports legacy `vim_modal_input`, normalizes it as a boolean, and defaults to `true` when unset.
* **Documentation**
  * Reformatted the README “Copy Mode” table and added guidance for modal dialog inputs, including how to disable them.
* **Tests**
  * Added/expanded Bun test coverage for modal input controls and single-line Vim motions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->