### PR TITLE
feat: support langmap in modal inputs

### DIFF
--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -18,6 +18,7 @@ import {
   createSingleLineVimMotions,
   isSingleLineVimPrintableKey,
   singleLineVimKeyName,
+  singleLineVimLangmappedEvent,
   type SingleLineVimKeyEvent,
 } from "../../ui/single-line-vim-motions"
 import type { ModalInputMode } from "../../ui/modal-input-controls"
@@ -153,7 +154,8 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       answerMotions.clearPending()
       return false
     }
-    const key = answerKeyName(event)
+    const mappedEvent = store.inputMode === "normal" ? singleLineVimLangmappedEvent(event, () => tuiConfig.vim_langmap) : event
+    const key = answerKeyName(mappedEvent)
     if (store.inputMode === "insert") {
       if (key !== "escape") return false
       enterAnswerNormalMode()
@@ -168,12 +170,12 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       }
       setStore("inputMode", "insert")
       textarea?.focus()
-      event.preventDefault()
+      mappedEvent.preventDefault()
       return true
     }
-    if (answerMotions.handleKey(event)) return true
+    if (answerMotions.handleKey(mappedEvent)) return true
     if (isSingleLineVimPrintableKey(key) || key === "backspace" || key === "delete") {
-      event.preventDefault()
+      mappedEvent.preventDefault()
       return true
     }
     return false

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -150,6 +150,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       setStore("filter", text)
       props.onFilter?.(text)
     },
+    langmap: () => tuiConfig.vim_langmap,
   })
 
   createEffect(() => {

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -3,6 +3,7 @@ import {
   createSingleLineVimMotions,
   isSingleLineVimPrintableKey,
   singleLineVimKeyName,
+  singleLineVimLangmappedEvent,
   type SingleLineVimKeyEvent,
 } from "./single-line-vim-motions"
 
@@ -21,6 +22,7 @@ export function createModalInputControls(input: {
   cursor: () => number
   setCursor: (offset: number) => void
   setText: (text: string) => void
+  langmap?: () => Record<string, string> | undefined
 }) {
   let pending = ""
   const motions = createSingleLineVimMotions({
@@ -43,7 +45,8 @@ export function createModalInputControls(input: {
         motions.handleKey(event)
         return false
       }
-      const key = keyName(event)
+      const mappedEvent = input.mode() === "normal" ? singleLineVimLangmappedEvent(event, input.langmap) : event
+      const key = keyName(mappedEvent)
       if (input.mode() === "insert") {
         if (key !== "escape") return false
         pending = ""
@@ -60,46 +63,46 @@ export function createModalInputControls(input: {
         if (key === "a") input.setCursor(Math.min(input.text().length, input.cursor() + 1))
         input.setMode("insert")
         input.focus()
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
-      if (motions.handleKey(event)) {
+      if (motions.handleKey(mappedEvent)) {
         pending = ""
         return true
       }
       if (key === "j") {
         pending = ""
         input.move(1)
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "k") {
         pending = ""
         input.move(-1)
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "G") {
         pending = ""
         input.moveToEnd()
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "g") {
         if (pending === "g") {
           pending = ""
           input.moveToStart()
-          event.preventDefault()
+          mappedEvent.preventDefault()
           return true
         }
         pending = "g"
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
 
       pending = ""
       if (isSingleLineVimPrintableKey(key) || key === "backspace" || key === "delete") {
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       return false

--- a/packages/tui/src/ui/single-line-vim-motions.ts
+++ b/packages/tui/src/ui/single-line-vim-motions.ts
@@ -12,6 +12,7 @@ export function createSingleLineVimMotions(input: {
   setText: (text: string) => void
   enterInsert: () => void
   focus: () => void
+  langmap?: () => Record<string, string> | undefined
 }) {
   let pending = ""
 
@@ -24,68 +25,69 @@ export function createSingleLineVimMotions(input: {
         pending = ""
         return false
       }
-      const key = singleLineVimKeyName(event)
+      const mappedEvent = singleLineVimLangmappedEvent(event, input.langmap)
+      const key = singleLineVimKeyName(mappedEvent)
       if (key === "d") {
         if (pending === "d") {
           pending = ""
           input.setText("")
           input.setCursor(0)
-          event.preventDefault()
+          mappedEvent.preventDefault()
           return true
         }
         pending = "d"
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
 
       pending = ""
       if (key === "h") {
         input.setCursor(Math.max(0, input.cursor() - 1))
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "l") {
         input.setCursor(Math.min(normalCursorEnd(input.text()), input.cursor() + 1))
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "b") {
         input.setCursor(previousWordStart(input.text(), input.cursor()))
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "w") {
         input.setCursor(nextWordStart(input.text(), input.cursor()))
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "e") {
         input.setCursor(nextWordEnd(input.text(), input.cursor()))
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "0") {
         input.setCursor(0)
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "$") {
         input.setCursor(normalCursorEnd(input.text()))
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "I") {
         input.setCursor(0)
         input.enterInsert()
         input.focus()
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       if (key === "A") {
         input.setCursor(input.text().length)
         input.enterInsert()
         input.focus()
-        event.preventDefault()
+        mappedEvent.preventDefault()
         return true
       }
       return false
@@ -107,6 +109,25 @@ export function singleLineVimKeyName(event: KeyEvent) {
 
 export function isSingleLineVimPrintableKey(key: string) {
   return key.length === 1 || key === "space"
+}
+
+export function singleLineVimLangmappedEvent(
+  event: SingleLineVimKeyEvent,
+  langmap: (() => Record<string, string> | undefined) | undefined,
+): SingleLineVimKeyEvent {
+  const key = singleLineVimKeyName(event)
+  if (key.length !== 1) return event
+  const map = langmap?.()
+  const mapped = map?.[key] ?? (event.shift ? map?.[key.toLowerCase()]?.toUpperCase() : undefined)
+  if (!mapped || mapped.length !== 1) return event
+  return {
+    ...event,
+    name: mapped,
+    sequence: mapped,
+    raw: mapped,
+    shift: /[A-Z]/.test(mapped),
+    preventDefault: () => event.preventDefault(),
+  } as SingleLineVimKeyEvent
 }
 
 function hasModifier(event: KeyEvent) {

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -19,7 +19,7 @@ function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: 
   } as ModalInputKeyEvent
 }
 
-function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?: number }) {
+function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?: number; langmap?: Record<string, string> }) {
   let mode = input?.mode ?? "normal"
   let text = input?.text ?? ""
   let cursor = input?.cursor ?? 0
@@ -35,6 +35,7 @@ function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?:
     cursor: () => cursor,
     setCursor: (next) => (cursor = next),
     setText: (next) => (text = next),
+    langmap: () => input?.langmap,
   })
 
   return { controls, moves, mode: () => mode, cursor: () => cursor, text: () => text }
@@ -121,6 +122,18 @@ describe("modal input controls", () => {
     state.controls.handleKey(key("g"))
     state.controls.handleKey(key("g", { sequence: "G", shift: true }))
     expect(state.moves).toEqual([-100, 100])
+  })
+
+  test("applies langmap to normal-mode picker controls", () => {
+    const state = createControls({ langmap: { о: "j", л: "k", п: "g" } })
+
+    state.controls.handleKey(key("о", { sequence: "о" }))
+    state.controls.handleKey(key("л", { sequence: "л" }))
+    state.controls.handleKey(key("п", { sequence: "п" }))
+    state.controls.handleKey(key("п", { sequence: "п" }))
+    state.controls.handleKey(key("п", { sequence: "П", shift: true }))
+
+    expect(state.moves).toEqual([1, -1, -100, 100])
   })
 
   test("supports basic cursor motions", () => {

--- a/packages/tui/test/single-line-vim-motions.test.ts
+++ b/packages/tui/test/single-line-vim-motions.test.ts
@@ -19,7 +19,7 @@ function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: 
   } as SingleLineVimKeyEvent
 }
 
-function createMotions(input: { text?: string; cursor?: number } = {}) {
+function createMotions(input: { text?: string; cursor?: number; langmap?: Record<string, string> } = {}) {
   let text = input.text ?? ""
   let cursor = input.cursor ?? 0
   let insert = false
@@ -30,6 +30,7 @@ function createMotions(input: { text?: string; cursor?: number } = {}) {
     setText: (next) => (text = next),
     enterInsert: () => (insert = true),
     focus() {},
+    langmap: () => input.langmap,
   })
 
   return { motions, cursor: () => cursor, insert: () => insert, text: () => text }
@@ -65,6 +66,18 @@ describe("single line vim motions", () => {
     end.motions.handleKey(key("a", { sequence: "A", shift: true }))
     expect(end.cursor()).toBe(5)
     expect(end.insert()).toBe(true)
+  })
+
+  test("applies langmap to motions", () => {
+    const state = createMotions({ text: "alpha", cursor: 2, langmap: { р: "h", д: "l", ш: "i" } })
+
+    state.motions.handleKey(key("р", { sequence: "р" }))
+    expect(state.cursor()).toBe(1)
+    state.motions.handleKey(key("д", { sequence: "д" }))
+    expect(state.cursor()).toBe(2)
+    state.motions.handleKey(key("ш", { sequence: "Ш", shift: true }))
+    expect(state.cursor()).toBe(0)
+    expect(state.insert()).toBe(true)
   })
 
   test("clears the line with dd", () => {


### PR DESCRIPTION
 Adds `vim_langmap` support to modal dialog inputs so normal mode controls work with mapped keyboard layouts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vim `langmap` support in TUI keyboard handling, so remapped keys now work in normal mode for motion and answer input controls.
  * Improved handling of mapped uppercase and repeated keystrokes for more consistent navigation behavior.

* **Bug Fixes**
  * Fixed default key suppression so it now applies correctly to remapped keys instead of the original input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->