### PR TITLE
feat: support escape sequence in modal inputs

### DIFF
--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -21,7 +21,7 @@ import {
   singleLineVimLangmappedEvent,
   type SingleLineVimKeyEvent,
 } from "../../ui/single-line-vim-motions"
-import type { ModalInputMode } from "../../ui/modal-input-controls"
+import { createModalInputEscapeSequence, type ModalInputMode } from "../../ui/modal-input-controls"
 import { useVimEnabled } from "../../component/vim"
 
 const QUESTION_MODE = "question"
@@ -77,6 +77,20 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     },
     enterInsert: () => setStore("inputMode", "insert"),
     focus: () => textarea?.focus(),
+  })
+  const answerEscapeSequence = createModalInputEscapeSequence({
+    vimEscapeSequence: () => tuiConfig.vim_escape_sequence,
+    text: () => textarea?.plainText ?? "",
+    cursor: () => textarea?.cursorOffset ?? 0,
+    setCursor: (offset) => {
+      if (!textarea || textarea.isDestroyed) return
+      textarea.cursorOffset = offset
+    },
+    setText: (text) => {
+      if (!textarea || textarea.isDestroyed) return
+      textarea.setText(text)
+    },
+    enterNormal: () => enterAnswerNormalMode(),
   })
 
   createEffect(() => {
@@ -151,20 +165,21 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   function handleAnswerKey(event: SingleLineVimKeyEvent) {
     if (!modalInputEnabled()) return false
     if (hasModifier(event)) {
-      answerMotions.clearPending()
+      clearAnswerPending()
       return false
     }
     const mappedEvent = store.inputMode === "normal" ? singleLineVimLangmappedEvent(event, () => tuiConfig.vim_langmap) : event
     const key = answerKeyName(mappedEvent)
     if (store.inputMode === "insert") {
-      if (key !== "escape") return false
+      if (key !== "escape") return answerEscapeSequence.handleKey(event)
+      clearAnswerPending()
       enterAnswerNormalMode()
       event.preventDefault()
       return true
     }
     if (key === "escape") return false
     if (key === "i" || key === "a" || key === "/") {
-      answerMotions.clearPending()
+      clearAnswerPending()
       if (key === "a" && textarea && !textarea.isDestroyed) {
         textarea.cursorOffset = Math.min(textarea.plainText.length, textarea.cursorOffset + 1)
       }
@@ -181,8 +196,13 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     return false
   }
 
-  function setEditing(editing: boolean) {
+  function clearAnswerPending() {
     answerMotions.clearPending()
+    answerEscapeSequence.clearPending()
+  }
+
+  function setEditing(editing: boolean) {
+    clearAnswerPending()
     setStore("editing", editing)
   }
 
@@ -225,7 +245,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         title: "Clear answer edit",
         category: "Question",
         run() {
-          answerMotions.clearPending()
+          clearAnswerPending()
           const text = textarea?.plainText ?? ""
           if (!text) {
             setEditing(false)
@@ -265,7 +285,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         desc: "Submit answer edit",
         group: "Question",
         cmd: () => {
-          answerMotions.clearPending()
+          clearAnswerPending()
           const text = textarea?.plainText?.trim() ?? ""
           const prev = store.custom[store.tab]
 

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -103,6 +103,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   let selection: { value: T; category?: string } | undefined
   let resetSelection = false
   let visibilityGeneration = 0
+  let filterSelectionGeneration = 0
 
   createEffect(
     on(
@@ -151,6 +152,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       props.onFilter?.(text)
     },
     langmap: () => tuiConfig.vim_langmap,
+    vimEscapeSequence: () => tuiConfig.vim_escape_sequence,
   })
 
   createEffect(() => {
@@ -328,15 +330,17 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   createEffect(
     on([() => store.filter, () => props.current], ([filter, current]) => {
+      const generation = ++filterSelectionGeneration
       if (filter.length > 0) resetSelection = true
       setTimeout(() => {
+        if (generation !== filterSelectionGeneration) return
         if (filter.length > 0) {
-          moveTo(0, true, false)
-        } else if (current) {
+          moveTo(0, true, false, false)
+          return
+        }
+        if (current) {
           const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
-          if (currentIndex >= 0) {
-            moveTo(currentIndex, true)
-          }
+          if (currentIndex >= 0) moveTo(currentIndex, true)
         }
       }, 0)
     }),
@@ -352,8 +356,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     moveTo(next, true)
   }
 
-  function moveTo(next: number, center = false, preserve = true) {
-    clearModalInputPending()
+  function moveTo(next: number, center = false, preserve = true, clearPending = true) {
+    if (clearPending) clearModalInputPending()
     if (next < 0) return
     setFocusedAction(undefined)
     setStore("selected", next)

--- a/packages/tui/src/ui/modal-input-controls.ts
+++ b/packages/tui/src/ui/modal-input-controls.ts
@@ -23,8 +23,21 @@ export function createModalInputControls(input: {
   setCursor: (offset: number) => void
   setText: (text: string) => void
   langmap?: () => Record<string, string> | undefined
+  vimEscapeSequence?: () => string | undefined
 }) {
   let pending = ""
+  const enterNormal = () => {
+    input.setCursor(normalCursor(input.text(), input.cursor()))
+    input.setMode("normal")
+  }
+  const escapeSequence = createModalInputEscapeSequence({
+    vimEscapeSequence: input.vimEscapeSequence,
+    text: input.text,
+    cursor: input.cursor,
+    setCursor: input.setCursor,
+    setText: input.setText,
+    enterNormal,
+  })
   const motions = createSingleLineVimMotions({
     text: input.text,
     cursor: input.cursor,
@@ -38,22 +51,26 @@ export function createModalInputControls(input: {
     clearPending() {
       pending = ""
       motions.clearPending()
+      escapeSequence.clearPending()
     },
     handleKey(event: ModalInputKeyEvent) {
       if (hasModifier(event)) {
         pending = ""
         motions.handleKey(event)
+        escapeSequence.clearPending()
         return false
       }
       const mappedEvent = input.mode() === "normal" ? singleLineVimLangmappedEvent(event, input.langmap) : event
       const key = keyName(mappedEvent)
       if (input.mode() === "insert") {
-        if (key !== "escape") return false
-        pending = ""
-        input.setCursor(normalCursor(input.text(), input.cursor()))
-        input.setMode("normal")
-        event.preventDefault()
-        return true
+        if (key === "escape") {
+          pending = ""
+          escapeSequence.clearPending()
+          enterNormal()
+          event.preventDefault()
+          return true
+        }
+        return escapeSequence.handleKey(event)
       }
 
       if (key === "escape") return false
@@ -106,6 +123,64 @@ export function createModalInputControls(input: {
         return true
       }
       return false
+    },
+  }
+}
+
+export function createModalInputEscapeSequence(input: {
+  vimEscapeSequence: (() => string | undefined) | undefined
+  text: () => string
+  cursor: () => number
+  setCursor: (offset: number) => void
+  setText: (text: string) => void
+  enterNormal: () => void
+}) {
+  let pending: string | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  function cancelPending() {
+    pending = undefined
+    if (!timer) return
+    clearTimeout(timer)
+    timer = undefined
+  }
+
+  function insert(value: string) {
+    const cursor = input.cursor()
+    input.setText(input.text().slice(0, cursor) + value + input.text().slice(cursor))
+    input.setCursor(cursor + value.length)
+  }
+
+  function clearPending() {
+    const value = pending
+    cancelPending()
+    if (value) insert(value)
+  }
+
+  return {
+    clearPending,
+    handleKey(event: ModalInputKeyEvent) {
+      const sequence = input.vimEscapeSequence?.()
+      if (!sequence) {
+        clearPending()
+        return false
+      }
+      const key = singleLineVimKeyName(event)
+      if (pending) {
+        if (key !== sequence[1] || hasModifier(event)) {
+          clearPending()
+          return false
+        }
+        cancelPending()
+        input.enterNormal()
+        event.preventDefault()
+        return true
+      }
+      if (key !== sequence[0] || hasModifier(event)) return false
+      pending = sequence[0]
+      timer = setTimeout(clearPending, 300)
+      event.preventDefault()
+      return true
     },
   }
 }

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -19,7 +19,13 @@ function key(name: string, input?: { sequence?: string; shift?: boolean; ctrl?: 
   } as ModalInputKeyEvent
 }
 
-function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?: number; langmap?: Record<string, string> }) {
+function createControls(input?: {
+  mode?: ModalInputMode
+  text?: string
+  cursor?: number
+  langmap?: Record<string, string>
+  vimEscapeSequence?: string
+}) {
   let mode = input?.mode ?? "normal"
   let text = input?.text ?? ""
   let cursor = input?.cursor ?? 0
@@ -36,9 +42,15 @@ function createControls(input?: { mode?: ModalInputMode; text?: string; cursor?:
     setCursor: (next) => (cursor = next),
     setText: (next) => (text = next),
     langmap: () => input?.langmap,
+    vimEscapeSequence: () => input?.vimEscapeSequence,
   })
 
-  return { controls, moves, mode: () => mode, cursor: () => cursor, text: () => text }
+  function insert(value: string) {
+    text = text.slice(0, cursor) + value + text.slice(cursor)
+    cursor += value.length
+  }
+
+  return { controls, moves, mode: () => mode, cursor: () => cursor, text: () => text, insert }
 }
 
 describe("modal input controls", () => {
@@ -90,6 +102,52 @@ describe("modal input controls", () => {
 
     expect(middle.mode()).toBe("normal")
     expect(middle.cursor()).toBe(1)
+  })
+
+  test("uses configured escape sequence to enter normal mode", () => {
+    const state = createControls({ mode: "insert", text: "alpha", cursor: 2, vimEscapeSequence: "jk" })
+
+    const first = key("j")
+    expect(state.controls.handleKey(first)).toBe(true)
+    expect(first.defaultPrevented).toBe(true)
+    expect(state.text()).toBe("alpha")
+
+    const second = key("k")
+    expect(state.controls.handleKey(second)).toBe(true)
+    expect(second.defaultPrevented).toBe(true)
+    expect(state.mode()).toBe("normal")
+    expect(state.text()).toBe("alpha")
+    expect(state.cursor()).toBe(1)
+  })
+
+  test("keeps text when escape sequence does not match", () => {
+    const state = createControls({ mode: "insert", text: "alpha", cursor: 2, vimEscapeSequence: "jk" })
+
+    const first = key("j")
+    expect(state.controls.handleKey(first)).toBe(true)
+    expect(first.defaultPrevented).toBe(true)
+    expect(state.text()).toBe("alpha")
+    expect(state.controls.handleKey(key("x"))).toBe(false)
+    state.insert("x")
+
+    expect(state.mode()).toBe("insert")
+    expect(state.text()).toBe("aljxpha")
+  })
+
+  test("clears pending escape sequence before passing modified keys through", () => {
+    const state = createControls({ mode: "insert", text: "alpha", cursor: 2, vimEscapeSequence: "jk" })
+
+    state.controls.handleKey(key("j"))
+
+    const modified = key("k", { ctrl: true })
+    expect(state.controls.handleKey(modified)).toBe(false)
+    expect(modified.defaultPrevented).toBe(false)
+
+    expect(state.controls.handleKey(key("k"))).toBe(false)
+    state.insert("k")
+
+    expect(state.mode()).toBe("insert")
+    expect(state.text()).toBe("aljkpha")
   })
 
   test("clears pending picker motions before passing ctrl bindings to the outer keymap", () => {


### PR DESCRIPTION
Adds `vim_escape_sequence` support to modal inputs, allowing sequences like jk to leave insert mode in dialog filters.
