### PR TITLE
ci: keep nix hash workflow enabled

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
-          keep="ci.yml publish-ocv.yml sync-upstream.yml"
+          keep="ci.yml publish-ocv.yml sync-upstream.yml nix-hashes.yml"
           gh api repos/${{ github.repository }}/actions/workflows --paginate -q '.workflows[] | "\(.id) \(.path)"' | while read id path; do
             name=$(basename "$path")
             if echo "$keep" | grep -qw "$name"; then


### PR DESCRIPTION
Keep `nix-hashes.yml` enabled after upstream sync.

#189