### PR TITLE
feat: add s/S motion for dialog inputs

### DIFF
--- a/packages/tui/src/ui/single-line-vim-motions.ts
+++ b/packages/tui/src/ui/single-line-vim-motions.ts
@@ -41,6 +41,26 @@ export function createSingleLineVimMotions(input: {
       }
 
       pending = ""
+      if (key === "s") {
+        const text = input.text()
+        const cursor = input.cursor()
+        if (cursor < text.length) {
+          input.setText(text.slice(0, cursor) + text.slice(cursor + 1))
+          input.setCursor(Math.min(cursor, text.length - 1))
+        }
+        input.enterInsert()
+        input.focus()
+        mappedEvent.preventDefault()
+        return true
+      }
+      if (key === "S") {
+        input.setText("")
+        input.setCursor(0)
+        input.enterInsert()
+        input.focus()
+        mappedEvent.preventDefault()
+        return true
+      }
       if (key === "h") {
         input.setCursor(Math.max(0, input.cursor() - 1))
         mappedEvent.preventDefault()
@@ -103,6 +123,7 @@ export function singleLineVimKeyName(event: KeyEvent) {
   if (text) return text
   if (event.shift && event.name === "i") return "I"
   if (event.shift && event.name === "a") return "A"
+  if (event.shift && event.name === "s") return "S"
   if (event.shift && event.name === "4") return "$"
   return event.name ?? ""
 }

--- a/packages/tui/test/modal-input-controls.test.ts
+++ b/packages/tui/test/modal-input-controls.test.ts
@@ -213,6 +213,21 @@ describe("modal input controls", () => {
     expect(state.cursor()).toBe(15)
   })
 
+  test("supports s and S substitute motions", () => {
+    const substitute = createControls({ text: "alpha", cursor: 2 })
+
+    substitute.controls.handleKey(key("s"))
+    expect(substitute.text()).toBe("alha")
+    expect(substitute.cursor()).toBe(2)
+    expect(substitute.mode()).toBe("insert")
+
+    const line = createControls({ text: "alpha", cursor: 2 })
+    line.controls.handleKey(key("s", { sequence: "S", shift: true }))
+    expect(line.text()).toBe("")
+    expect(line.cursor()).toBe(0)
+    expect(line.mode()).toBe("insert")
+  })
+
   test("supports i and a insert motions", () => {
     const insert = createControls({ text: "alpha", cursor: 2 })
 

--- a/packages/tui/test/single-line-vim-motions.test.ts
+++ b/packages/tui/test/single-line-vim-motions.test.ts
@@ -80,6 +80,50 @@ describe("single line vim motions", () => {
     expect(state.insert()).toBe(true)
   })
 
+  test("substitutes the character under cursor", () => {
+    const state = createMotions({ text: "alpha", cursor: 2 })
+
+    state.motions.handleKey(key("s"))
+
+    expect(state.text()).toBe("alha")
+    expect(state.cursor()).toBe(2)
+    expect(state.insert()).toBe(true)
+  })
+
+  test("substitutes the last character under cursor", () => {
+    const state = createMotions({ text: "alpha", cursor: 4 })
+
+    state.motions.handleKey(key("s"))
+
+    expect(state.text()).toBe("alph")
+    expect(state.cursor()).toBe(4)
+    expect(state.insert()).toBe(true)
+  })
+
+  test("substitutes the line", () => {
+    const state = createMotions({ text: "alpha", cursor: 2 })
+
+    state.motions.handleKey(key("s", { sequence: "S", shift: true }))
+
+    expect(state.text()).toBe("")
+    expect(state.cursor()).toBe(0)
+    expect(state.insert()).toBe(true)
+  })
+
+  test("clears pending operators before substituting", () => {
+    const lower = createMotions({ text: "alpha", cursor: 2 })
+
+    lower.motions.handleKey(key("d"))
+    lower.motions.handleKey(key("s"))
+    expect(lower.text()).toBe("alha")
+
+    const upper = createMotions({ text: "alpha", cursor: 2 })
+
+    upper.motions.handleKey(key("d"))
+    upper.motions.handleKey(key("s", { sequence: "S", shift: true }))
+    expect(upper.text()).toBe("")
+  })
+
   test("clears the line with dd", () => {
     const state = createMotions({ text: "alpha", cursor: 2 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vim-style substitute motions in single-line text input.
  * Pressing `s` replaces the character at the cursor and enters insert mode.
  * Pressing `S` clears the line and enters insert mode.
* **Bug Fixes**
  * Improved handling of substitute motions when used after other pending key commands.
* **Tests**
  * Added coverage for substitute behavior, including cursor movement, line clearing, and insert-mode transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->