### PR TITLE
fix: mirror tool keyboard hover

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -815,7 +815,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         name: "vim.q",
         title: ":q",
         slashName: "q",
-        desc: "Exit OpenCode",
+        desc: "quit",
         run: () => exit(),
         category: "System",
       },

--- a/packages/tui/src/routes/session/copy-overlay.tsx
+++ b/packages/tui/src/routes/session/copy-overlay.tsx
@@ -31,15 +31,6 @@ export function CopyOverlay(props: { copy?: CopyPosition; topOffset?: number; hi
           backgroundColor={RGBA.fromInts(255, 255, 255, 15)}
         />
       </Show>
-      <Show when={!props.copy?.visual ? props.copy?.action : undefined}>
-        {(action) => (
-          <box position="absolute" top={top(props.copy!.line)} left={action().left}>
-            <text bg={RGBA.fromInts(255, 255, 255, 25)} fg={theme.textMuted}>
-              {action().text}
-            </text>
-          </box>
-        )}
-      </Show>
       <For each={props.highlights ?? []}>
         {(highlight) => {
           const background = () =>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1915,7 +1915,7 @@ type ToolProps = {
   tool: string
   output?: string
   part: ToolPart
-  copy?: CopyRow
+  copy?: CopyContext
 }
 function GenericTool(props: ToolProps) {
   const { theme } = useTheme()
@@ -1929,6 +1929,9 @@ function GenericTool(props: ToolProps) {
     if (expanded() || !collapsed().overflow) return output()
     return collapsed().output
   })
+  const keyboardHover = createMemo(() =>
+    Boolean(props.copy?.kind === "tool" && props.copy.part === props.part.id && props.copy.action),
+  )
 
   createEffect(() => {
     if (!collapsed().overflow) return
@@ -1959,7 +1962,9 @@ function GenericTool(props: ToolProps) {
         <box gap={1}>
           <text fg={theme.text}>{limited()}</text>
           <Show when={collapsed().overflow}>
-            <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
+            <text fg={keyboardHover() ? theme.text : theme.textMuted}>
+              {expanded() ? "Click to collapse" : "Click to expand"}
+            </text>
           </Show>
         </box>
       </BlockTool>
@@ -2193,6 +2198,9 @@ function Shell(props: ToolProps) {
     if (expanded() || !collapsed().overflow) return output()
     return collapsed().output
   })
+  const keyboardHover = createMemo(() =>
+    Boolean(props.copy?.kind === "tool" && props.copy.part === props.part.id && props.copy.action),
+  )
 
   createEffect(() => {
     if (!collapsed().overflow) return
@@ -2236,7 +2244,9 @@ function Shell(props: ToolProps) {
               <text fg={theme.text}>{limited()}</text>
             </Show>
             <Show when={collapsed().overflow}>
-              <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
+              <text fg={keyboardHover() ? theme.text : theme.textMuted}>
+                {expanded() ? "Click to collapse" : "Click to expand"}
+              </text>
             </Show>
           </box>
         </BlockTool>


### PR DESCRIPTION
Updates keyboard selection styling for expandable tool output rows in copy mode.
