### PR TITLE
ci: refresh nix hashes after upstream sync

### DIFF
--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [ocv, dev, beta]
+    branches: [ocv]
     paths:
       - "bun.lock"
       - "package.json"
@@ -18,13 +18,14 @@ on:
       - ".github/workflows/nix-hashes.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: nix-hashes-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   # Native runners required: bun install cross-compilation flags (--os/--cpu)
   # do not produce byte-identical node_modules as native installs.
   compute-hash:
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip nix-hashes]')
     strategy:
       fail-fast: false
       matrix:
@@ -80,20 +81,62 @@ jobs:
         run: |
           git pull --rebase --autostash origin "$GITHUB_REF_NAME"
 
+      - name: Check branch revision
+        id: revision
+        run: |
+          set -euo pipefail
+          git fetch origin "+refs/heads/$GITHUB_REF_NAME:refs/remotes/origin/$GITHUB_REF_NAME"
+          if [ "$(git rev-parse "origin/$GITHUB_REF_NAME")" != "$GITHUB_SHA" ] && ! git diff --quiet "$GITHUB_SHA" "origin/$GITHUB_REF_NAME" -- \
+            bun.lock \
+            package.json \
+            'packages/*/package.json' \
+            flake.lock \
+            nix/node_modules.nix \
+            nix/scripts \
+            patches; then
+            echo "Branch hash inputs changed since this run started; skipping stale hash update."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "### Nix hashes" >> "$GITHUB_STEP_SUMMARY"
+            echo "Status: skipped because branch hash inputs changed" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "current=true" >> "$GITHUB_OUTPUT"
+
       - name: Download hash artifacts
+        if: steps.revision.outputs.current == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: hashes
           pattern: hash-*
 
       - name: Update hashes.json
+        if: steps.revision.outputs.current == 'true'
         run: nix/scripts/update-node-modules-hashes-json.sh hashes nix/hashes.json warn
 
       - name: Commit changes
+        if: steps.revision.outputs.current == 'true'
         run: |
           set -euo pipefail
 
           HASH_FILE="nix/hashes.json"
+
+          git fetch origin "+refs/heads/$GITHUB_REF_NAME:refs/remotes/origin/$GITHUB_REF_NAME"
+          if [ "$(git rev-parse "origin/$GITHUB_REF_NAME")" != "$(git rev-parse HEAD)" ]; then
+            if ! git diff --quiet "$GITHUB_SHA" "origin/$GITHUB_REF_NAME" -- \
+              bun.lock \
+              package.json \
+              'packages/*/package.json' \
+              flake.lock \
+              nix/node_modules.nix \
+              nix/scripts \
+              patches; then
+              echo "Branch hash inputs changed before commit; skipping stale hash update."
+              echo "### Nix hashes" >> "$GITHUB_STEP_SUMMARY"
+              echo "Status: skipped because branch hash inputs changed" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            git pull --rebase --autostash origin "$GITHUB_REF_NAME"
+          fi
 
           if [ -z "$(git status --short -- "$HASH_FILE")" ]; then
             echo "No changes to commit"
@@ -104,8 +147,6 @@ jobs:
 
           git add "$HASH_FILE"
           git commit -m "chore: update nix node_modules hashes"
-
-          git pull --rebase --autostash origin "$GITHUB_REF_NAME"
           git push origin HEAD:"$GITHUB_REF_NAME"
 
           echo "### Nix hashes" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-ocv.yml
+++ b/.github/workflows/publish-ocv.yml
@@ -7,11 +7,20 @@ on:
         description: "Version (e.g. 1.2.20)"
         required: true
         type: string
+      force_nix_hash_refresh:
+        description: "Force Nix hash refresh"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
   issues: write
   pull-requests: read
+
+concurrency:
+  group: release-ocv-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   prepare:
@@ -60,6 +69,13 @@ jobs:
           fi
 
           echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ inputs.force_nix_hash_refresh }}" = "true" ]; then
+            echo "Nix hash refresh forced"
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           HASH_BASE=$(git log -n 1 --format=%H -- nix/hashes.json || true)
 
           if [ -n "$HASH_BASE" ] && git diff --quiet "$HASH_BASE"..HEAD -- \
@@ -68,8 +84,7 @@ jobs:
             'packages/*/package.json' \
             flake.lock \
             nix/node_modules.nix \
-            nix/scripts/canonicalize-node-modules.ts \
-            nix/scripts/normalize-bun-binaries.ts \
+            nix/scripts \
             patches; then
             echo "Nix hashes are current"
             echo "current=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -24,6 +24,7 @@ jobs:
           token: ${{ secrets.SYNC_PAT }}
 
       - name: Merge upstream/dev
+        id: merge
         run: |
           set -euo pipefail
 
@@ -32,13 +33,46 @@ jobs:
           git remote add upstream https://github.com/sst/opencode.git
           git fetch upstream dev
 
+          before=$(git rev-parse HEAD)
+          nix_hash_conflict_resolved=false
+          nix_hash_inputs_changed=false
+
           if ! git merge --no-commit --no-ff upstream/dev; then
             conflicts=$(git diff --name-only --diff-filter=U)
-            other_conflicts=$(printf '%s\n' "$conflicts" | grep -vx 'AGENTS.md' || true)
+            other_conflicts=$(printf '%s\n' "$conflicts" | grep -Ev '^(AGENTS\.md|nix/hashes\.json)$' || true)
 
             if [ -n "$other_conflicts" ]; then
               printf '%s\n' "$other_conflicts"
               exit 1
+            fi
+
+            if printf '%s\n' "$conflicts" | grep -qx 'nix/hashes.json'; then
+              tmp=$(mktemp -d)
+              git show :2:nix/hashes.json > "$tmp/ours.json"
+              git show :3:nix/hashes.json > "$tmp/theirs.json"
+              python3 - "$tmp/ours.json" "$tmp/theirs.json" <<'PY'
+          import json
+          import sys
+
+          systems = {"x86_64-linux", "aarch64-linux", "aarch64-darwin", "x86_64-darwin"}
+          for path in sys.argv[1:]:
+              with open(path) as f:
+                  data = json.load(f)
+              if set(data) != {"nodeModules"}:
+                  raise SystemExit(f"Unsupported nix/hashes.json schema in {path}")
+              hashes = data["nodeModules"]
+              if set(hashes) != systems:
+                  raise SystemExit(f"Unsupported nix/hashes.json systems in {path}")
+              for system, value in hashes.items():
+                  if not isinstance(value, str) or not value.startswith("sha256-"):
+                      raise SystemExit(f"Unsupported nix hash for {system} in {path}")
+          PY
+              rm -rf "$tmp"
+
+              echo "Resolving nix/hashes.json with current OCV hashes; native hash refresh will run after push."
+              git checkout --ours -- nix/hashes.json
+              git add nix/hashes.json
+              nix_hash_conflict_resolved=true
             fi
           fi
 
@@ -46,11 +80,40 @@ jobs:
             git rm -f AGENTS.md
           fi
 
+          remaining_conflicts=$(git diff --name-only --diff-filter=U)
+          if [ -n "$remaining_conflicts" ]; then
+            printf '%s\n' "$remaining_conflicts"
+            exit 1
+          fi
+
           if git rev-parse -q --verify MERGE_HEAD >/dev/null; then
             git commit --no-edit
           elif ! git diff --cached --quiet; then
             git commit -m "chore: remove upstream agents file"
           fi
+
+          after=$(git rev-parse HEAD)
+          if [ "$before" != "$after" ] && ! git diff --quiet "$before" "$after" -- \
+            bun.lock \
+            package.json \
+            'packages/*/package.json' \
+            flake.lock \
+            nix/node_modules.nix \
+            nix/scripts \
+            patches; then
+            nix_hash_inputs_changed=true
+          fi
+
+          # Dependency-input changes pushed to ocv already trigger nix-hashes.yml via
+          # its push paths. Only dispatch manually for a resolved hashes.json conflict
+          # that would otherwise be invisible to that push trigger.
+          nix_hashes_needed=false
+          if [ "$nix_hash_conflict_resolved" = true ] && [ "$nix_hash_inputs_changed" != true ]; then
+            nix_hashes_needed=true
+          fi
+
+          echo "nix_hashes_needed=$nix_hashes_needed" >> "$GITHUB_OUTPUT"
+          echo "nix_hash_inputs_changed=$nix_hash_inputs_changed" >> "$GITHUB_OUTPUT"
 
       - name: Bump ocv track for ocv PRs
         env:
@@ -98,22 +161,6 @@ jobs:
           echo "Bumped ocv track from $track to $next for ocv PRs merged since $previous:"
           cat "$prs"
 
-      - name: Push
-        run: git push origin ocv
-
-      - name: Disable upstream workflows
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT }}
-        run: |
-          keep="ci.yml publish-ocv.yml sync-upstream.yml nix-hashes.yml"
-          gh api repos/${{ github.repository }}/actions/workflows --paginate -q '.workflows[] | "\(.id) \(.path)"' | while read id path; do
-            name=$(basename "$path")
-            if echo "$keep" | grep -qw "$name"; then
-              continue
-            fi
-            gh api -X PUT "repos/${{ github.repository }}/actions/workflows/$id/disable" 2>/dev/null || true
-          done
-
       - name: Check for new upstream version
         id: version
         env:
@@ -145,11 +192,49 @@ jobs:
           echo "release=$release" >> "$GITHUB_OUTPUT"
           echo "exists=$exists" >> "$GITHUB_OUTPUT"
 
+      - name: Mark release-managed Nix refresh
+        if: >-
+          steps.merge.outputs.nix_hash_inputs_changed == 'true' &&
+          steps.version.outputs.upstream_base != '' &&
+          steps.version.outputs.release != steps.version.outputs.current &&
+          steps.version.outputs.exists != 'true'
+        run: |
+          git commit --amend -m "$(git log -1 --format=%B)
+
+          [skip nix-hashes]"
+
+      - name: Push
+        run: git push origin ocv
+
+      - name: Disable upstream workflows
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          keep="ci.yml publish-ocv.yml sync-upstream.yml nix-hashes.yml"
+          gh api repos/${{ github.repository }}/actions/workflows --paginate -q '.workflows[] | "\(.id) \(.path)"' | while read id path; do
+            name=$(basename "$path")
+            if echo "$keep" | grep -qw "$name"; then
+              continue
+            fi
+            gh api -X PUT "repos/${{ github.repository }}/actions/workflows/$id/disable" 2>/dev/null || true
+          done
+
+      - name: Trigger Nix hash refresh
+        if: >-
+          steps.merge.outputs.nix_hashes_needed == 'true' &&
+          (steps.version.outputs.upstream_base == '' ||
+           steps.version.outputs.release == steps.version.outputs.current ||
+           steps.version.outputs.exists == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: gh workflow run nix-hashes.yml --repo ${{ github.repository }} --ref ocv
+
       - name: Trigger release
         if: steps.version.outputs.upstream_base != '' && steps.version.outputs.release != steps.version.outputs.current && steps.version.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}
-        run: gh workflow run publish-ocv.yml --repo ${{ github.repository }} --ref ocv -f version=${{ steps.version.outputs.release }}
+          FORCE_NIX_HASH_REFRESH: ${{ steps.merge.outputs.nix_hashes_needed }}
+        run: gh workflow run publish-ocv.yml --repo ${{ github.repository }} --ref ocv -f version=${{ steps.version.outputs.release }} -f force_nix_hash_refresh="$FORCE_NIX_HASH_REFRESH"
 
       - name: Close failure issue on success
         if: success()


### PR DESCRIPTION
Auto-resolve safe `nix/hashes.json` conflicts during upstream syncs and trigger the native Nix hash workflow afterward, so syncs don’t fail on mechanical hash conflicts while still recomputing correct platform hashes. 

Also avoids duplicate hash refreshes, lets releases refresh stale hashes themselves, and separates hash/release concurrency so pending releases aren’t cancelled. #189
