### PR TITLE
feat(prompt): support gj/gk display-line motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Toggle via command palette > `Toggle vim mode`.
 | ------------------------------ | ---------------------------------------------------------- |
 | Character / word               | `h`, `j`, `k`, `l`, `w`, `b`, `e`, `W`, `B`, `E`           |
 | Line / buffer                  | `0`, `^`, `_`, `$`, `gg`, `G`                              |
+| Display line                   | `gj`, `gk`, `g<Down>`, `g<Up>`                             |
 | Matching / paragraph           | `%`, `{`, `}`                                              |
 | Find / till                    | `f`, `F`, `t`, `T`, `;`, `,`                               |
 | Scroll                         | `Ctrl+e`, `Ctrl+y`, `Ctrl+d`, `Ctrl+u`, `Ctrl+f`, `Ctrl+b` |

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -8,6 +8,8 @@ import { createVimRepeat } from "./vim-repeat"
 import {
   appendAfterCursor,
   appendLineEnd,
+  alignVisualColumn,
+  clampCursorToLine,
   clearSelection,
   deleteLine,
   deleteLineEnd,
@@ -34,6 +36,8 @@ import {
   moveLineBeginning,
   moveLineDown,
   moveLineUp,
+  moveVisualLineDown,
+  moveVisualLineUp,
   moveMatchingBracket,
   moveNextParagraph,
   movePreviousParagraph,
@@ -190,6 +194,7 @@ export function createVimHandler(input: {
   vimEscapeSequence?: string
 }) {
   let wantedColumn: VimWantedColumn | undefined
+  let visualWantedColumn: number | undefined
   let pendingOperatorCount = 1
   let pendingOperatorFind: { operation: VimOperator; find: VimFindOperator } | undefined
   let pendingTextObject: { operation: VimOperator; scope: VimTextObjectScope } | undefined
@@ -262,6 +267,10 @@ export function createVimHandler(input: {
     wantedColumn = undefined
   }
 
+  function clearVisualWantedColumn() {
+    visualWantedColumn = undefined
+  }
+
   function repeatCount(count: number, run: () => void) {
     Array.from({ length: count }).forEach(() => run())
   }
@@ -327,6 +336,16 @@ export function createVimHandler(input: {
     return (key === "v" || isShifted(event, "v")) && !hasModifier(event)
   }
 
+  function preservesVisualWantedColumn(event: VimEvent, key: string) {
+    if (key === "g" && !event.shift && !hasModifier(event)) return true
+    return (
+      input.state.pending() === "g" &&
+      (key === "j" || key === "k" || key === "down" || key === "up") &&
+      !event.shift &&
+      !hasModifier(event)
+    )
+  }
+
   function snapshot(): VimSnapshot {
     if (input.snapshot) return input.snapshot()
     return {
@@ -337,6 +356,7 @@ export function createVimHandler(input: {
 
   function restore(next: VimSnapshot) {
     clearWantedColumn()
+    clearVisualWantedColumn()
     clearSelection(input.textarea())
     input.state.clearPending()
     input.state.setMode("normal")
@@ -516,6 +536,15 @@ export function createVimHandler(input: {
     const anchor = textarea.cursorOffset
     textarea.cursorOffset = start
     return substituteLine(textarea, anchor)
+  }
+
+  function moveDisplayVertical(direction: "up" | "down", count: number, column: number | undefined) {
+    repeatCount(count, () => {
+      direction === "down" ? moveVisualLineDown(input.textarea()) : moveVisualLineUp(input.textarea())
+      // Native visual moves can land on trailing newlines.
+      clampCursorToLine(input.textarea())
+      if (column !== undefined) alignVisualColumn(input.textarea(), column)
+    })
   }
 
   function lineMotionAnchor(direction: "up" | "down", count: number) {
@@ -777,6 +806,7 @@ export function createVimHandler(input: {
     const hadPending = !!input.state.pending()
     const hadCount = !!input.state.count()
     if (!preservesWantedColumn(event, key)) clearWantedColumn()
+    if (!preservesVisualWantedColumn(event, key)) clearVisualWantedColumn()
 
     if (input.state.pending() === "r") {
       if (hasModifier(event)) {
@@ -857,10 +887,29 @@ export function createVimHandler(input: {
       return true
     }
 
+    // Must run before vimJump, which clears pending g on non-g keys.
+    if (
+      input.state.pending() === "g" &&
+      (key === "j" || key === "k" || key === "down" || key === "up") &&
+      !event.shift &&
+      !hasModifier(event)
+    ) {
+      const direction = key === "j" || key === "down" ? "down" : "up"
+      const count = takeCount()
+      const view = input.textarea().editorView as { getVisualCursor?: () => { visualCol: number } }
+      visualWantedColumn ??= view.getVisualCursor?.().visualCol
+      input.state.clearPending()
+      clearWantedColumn()
+      moveDisplayVertical(direction, count, visualWantedColumn)
+      event.preventDefault()
+      return true
+    }
+
     const jump = vimJump(event, input.state)
     if (jump.handled) {
       if (jump.action) {
         input.state.clearPending()
+        clearVisualWantedColumn()
         input.jump(jump.action)
       }
       event.preventDefault()

--- a/packages/tui/src/component/vim/vim-motions.ts
+++ b/packages/tui/src/component/vim/vim-motions.ts
@@ -179,10 +179,37 @@ export function moveLineEnd(textarea: TextareaRenderable) {
   textarea.cursorOffset = lineLast(text, textarea.cursorOffset)
 }
 
-function clampCursorToLine(textarea: TextareaRenderable) {
+export function clampCursorToLine(textarea: TextareaRenderable) {
   const text = textarea.plainText
   const last = lineLast(text, textarea.cursorOffset)
   if (textarea.cursorOffset > last) textarea.cursorOffset = last
+}
+
+export function alignVisualColumn(textarea: TextareaRenderable, column: number) {
+  const view = textarea.editorView as {
+    getVisualCursor?: () => { visualRow: number; visualCol: number; offset: number }
+    setCursorByOffset?: (offset: number) => void
+  }
+  if (typeof view?.getVisualCursor !== "function") return
+
+  let cursor = view.getVisualCursor()
+  const row = cursor.visualRow
+  const text = textarea.plainText
+
+  while (cursor.visualCol < column) {
+    const next = textarea.cursorOffset + 1
+    if (next > lineLast(text, textarea.cursorOffset)) break
+
+    if (typeof view.setCursorByOffset === "function") view.setCursorByOffset(next)
+    else textarea.cursorOffset = next
+
+    const moved = view.getVisualCursor()
+    if (moved.offset === cursor.offset || moved.visualRow !== row) {
+      textarea.cursorOffset = cursor.offset
+      break
+    }
+    cursor = moved
+  }
 }
 
 export function moveRight(textarea: TextareaRenderable) {
@@ -199,6 +226,25 @@ export function moveLineUp(textarea: TextareaRenderable, column?: VimWantedColum
 export function moveLineDown(textarea: TextareaRenderable, column?: VimWantedColumn) {
   const text = textarea.plainText
   textarea.cursorOffset = moveDown(text, textarea.cursorOffset, column)
+}
+
+// Display-line motions delegate wrap handling to the editor view.
+export function moveVisualLineUp(textarea: TextareaRenderable) {
+  const view = textarea.editorView as { moveUpVisual?: () => void }
+  if (typeof view?.moveUpVisual === "function") {
+    view.moveUpVisual()
+    return
+  }
+  moveLineUp(textarea)
+}
+
+export function moveVisualLineDown(textarea: TextareaRenderable) {
+  const view = textarea.editorView as { moveDownVisual?: () => void }
+  if (typeof view?.moveDownVisual === "function") {
+    view.moveDownVisual()
+    return
+  }
+  moveLineDown(textarea)
 }
 
 export function moveMatchingBracket(textarea: TextareaRenderable) {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -5636,6 +5636,119 @@ describe("vim motion handler", () => {
     expect(ctx.jumpCalls.at(-1)).toBe("bottom")
   })
 
+  test("gj and gk move by display line and clear pending", () => {
+    const text = "abc\ndef\nghi"
+    const ctx = createHandler(text)
+    ctx.textarea.cursorOffset = rowColToOffset(text, 1, 1)
+
+    expect(ctx.handler.handleKey(createEvent("g").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("g")
+
+    const j = createEvent("j")
+    expect(ctx.handler.handleKey(j.event)).toBe(true)
+    expect(j.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.jumpCalls.length).toBe(0)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 2, 1))
+
+    expect(ctx.handler.handleKey(createEvent("g").event)).toBe(true)
+    const k = createEvent("k")
+    expect(ctx.handler.handleKey(k.event)).toBe(true)
+    expect(k.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.jumpCalls.length).toBe(0)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 1, 1))
+  })
+
+  test("gj in visual mode extends the selection", () => {
+    const text = "abc\ndef"
+    const ctx = createHandler(text)
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.state.mode()).toBe("visual")
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 1, 1))
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({
+      start: 1,
+      end: rowColToOffset(text, 1, 1) + 1,
+    })
+  })
+
+  test("g with arrow keys moves by display line", () => {
+    const text = "abc\ndef"
+    const ctx = createHandler(text)
+
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("down").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 1, 0))
+
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("up").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 0, 0))
+  })
+
+  test("counted gj repeats the display motion", () => {
+    const text = "a\nb\nc\nd"
+    const ctx = createHandler(text)
+
+    ctx.handler.handleKey(createEvent("3").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 3, 0))
+    expect(ctx.state.count()).toBe("")
+  })
+
+  test("repeated gj preserves desired visual column across short lines", () => {
+    const text = "abcd\ne\nijkl"
+    const ctx = createHandler(text)
+    const lineEnd = (offset: number) => {
+      const end = text.indexOf("\n", offset)
+      return end === -1 ? text.length : end
+    }
+    const nextLineStart = (offset: number) => {
+      const end = lineEnd(offset)
+      return end >= text.length ? undefined : end + 1
+    }
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => {
+      const { row, col } = offsetToRowCol(text, ctx.textarea.cursorOffset)
+      return { visualRow: row, visualCol: col, logicalRow: row, logicalCol: col, offset: ctx.textarea.cursorOffset }
+    }
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+    ;(ctx.textarea as any).editorView.moveDownVisual = () => {
+      const col = (ctx.textarea as any).editorView.getVisualCursor().visualCol
+      const start = nextLineStart(ctx.textarea.cursorOffset)
+      if (start === undefined) return
+      ctx.textarea.cursorOffset = Math.min(start + col, lineEnd(start))
+    }
+
+    ctx.textarea.cursorOffset = rowColToOffset(text, 0, 3)
+
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("j").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 1, 0))
+
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("j").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 2, 3))
+  })
+
+  test("gJ is not treated as display motion", () => {
+    const ctx = createHandler("ab\ncd")
+
+    ctx.handler.handleKey(createEvent("g").event)
+    const J = createEvent("J", { shift: true })
+    ctx.handler.handleKey(J.event)
+
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.textarea.plainText).toBe("ab cd")
+  })
+
   test("H, M, L jump to high, middle, and low", () => {
     const ctx = createHandler("abc")
 

--- a/packages/tui/test/vim-visual-line-motions.test.ts
+++ b/packages/tui/test/vim-visual-line-motions.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createTestRenderer } from "@opentui/core/testing"
+import { TextareaRenderable } from "@opentui/core"
+import { createVimHandler, type VimEvent } from "../src/component/vim/vim-handler"
+import { moveVisualLineDown, moveVisualLineUp } from "../src/component/vim/vim-motions"
+import { createVimState } from "../src/component/vim/vim-state"
+
+const WRAPPED = "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10"
+
+function createEvent(name: string): VimEvent {
+  return {
+    name,
+    preventDefault() {},
+  }
+}
+
+async function createWrappedTextarea(text: string) {
+  const setup = await createTestRenderer({ width: 20, height: 12, useThread: false })
+  const textarea = new TextareaRenderable(setup.renderer as any, { width: 20, height: 10 })
+  setup.renderer.root.add(textarea)
+  textarea.setText(text)
+  return {
+    textarea,
+    [Symbol.dispose]() {
+      setup.renderer.destroy()
+    },
+  }
+}
+
+async function createWrappedHandler(text: string) {
+  const setup = await createWrappedTextarea(text)
+  let disposeRoot!: () => void
+  const state = createRoot((dispose) => {
+    disposeRoot = dispose
+    return createVimState({ enabled: () => true, initial: () => "normal" })
+  })
+  const handler = createVimHandler({
+    enabled: () => true,
+    state,
+    textarea: () => setup.textarea,
+    submit() {},
+    scroll() {},
+    jump() {},
+  })
+  return {
+    textarea: setup.textarea,
+    handler,
+    [Symbol.dispose]() {
+      disposeRoot()
+      setup[Symbol.dispose]()
+    },
+  }
+}
+
+describe("visual line motions (gj/gk)", () => {
+  test("single logical line wraps into multiple display rows", async () => {
+    using ctx = await createWrappedTextarea(WRAPPED)
+    expect(WRAPPED.includes("\n")).toBe(false)
+    expect(ctx.textarea.virtualLineCount).toBeGreaterThan(1)
+  })
+
+  test("moveVisualLineDown moves one display row inside a wrapped line", async () => {
+    using ctx = await createWrappedTextarea(WRAPPED)
+    ctx.textarea.cursorOffset = 0
+
+    const before = ctx.textarea.editorView.getVisualCursor()
+    moveVisualLineDown(ctx.textarea)
+    const after = ctx.textarea.editorView.getVisualCursor()
+
+    expect(after.visualRow).toBe(before.visualRow + 1)
+    expect(after.logicalRow).toBe(0)
+    expect(ctx.textarea.cursorOffset).toBeGreaterThan(0)
+    expect(ctx.textarea.cursorOffset).toBeLessThan(WRAPPED.length)
+  })
+
+  test("moveVisualLineUp returns to the previous display row", async () => {
+    using ctx = await createWrappedTextarea(WRAPPED)
+    ctx.textarea.cursorOffset = 0
+
+    moveVisualLineDown(ctx.textarea)
+    const mid = ctx.textarea.cursorOffset
+    expect(mid).toBeGreaterThan(0)
+
+    moveVisualLineUp(ctx.textarea)
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("preserves goal column across shorter display rows", async () => {
+    using ctx = await createWrappedTextarea("aaaaaa bbbbbb cccc\ndd\neeeeee ffffff gggg")
+    ctx.textarea.cursorOffset = 10
+
+    moveVisualLineDown(ctx.textarea)
+    expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(2)
+
+    moveVisualLineDown(ctx.textarea)
+    expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(10)
+  })
+
+  test("stays put at the last display row", async () => {
+    using ctx = await createWrappedTextarea(WRAPPED)
+    ctx.textarea.cursorOffset = WRAPPED.length - 1
+    const before = ctx.textarea.editorView.getVisualCursor().visualRow
+
+    moveVisualLineDown(ctx.textarea)
+    expect(ctx.textarea.editorView.getVisualCursor().visualRow).toBe(before)
+  })
+
+  test("stays put at the first display row", async () => {
+    using ctx = await createWrappedTextarea(WRAPPED)
+    ctx.textarea.cursorOffset = 3
+
+    moveVisualLineUp(ctx.textarea)
+    expect(ctx.textarea.cursorOffset).toBe(3)
+  })
+
+  test("crosses logical line boundaries like a display row", async () => {
+    using ctx = await createWrappedTextarea("abc\ndef")
+    ctx.textarea.cursorOffset = 1
+
+    moveVisualLineDown(ctx.textarea)
+    expect(ctx.textarea.cursorOffset).toBe(5)
+  })
+
+  test("repeated gj preserves visual column across short rows", async () => {
+    using ctx = await createWrappedHandler("aaaaaa bbbbbb cccc\ndd\neeeeee ffffff gggg")
+    ctx.textarea.cursorOffset = 10
+
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("j"))
+    expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(1)
+
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("j"))
+    expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(10)
+  })
+})


### PR DESCRIPTION
 Part of #216

Adds `gj`/`gk` in prompt for moving by display lines across soft-wrapped input.
