### PR TITLE
feat(prompt): support operators for display-line motions

### DIFF
--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -197,6 +197,7 @@ export function createVimHandler(input: {
   let visualWantedColumn: number | undefined
   let pendingOperatorCount = 1
   let pendingOperatorFind: { operation: VimOperator; find: VimFindOperator } | undefined
+  let pendingOperatorDisplay: VimOperator | undefined
   let pendingTextObject: { operation: VimOperator; scope: VimTextObjectScope } | undefined
 
   // Two-key escape sequence support (e.g., "jk" to escape insert mode)
@@ -570,6 +571,83 @@ export function createVimHandler(input: {
     return { span, register: { text: textarea.plainText.slice(span.start, span.end), linewise: true } }
   }
 
+  function clearPendingOperatorDisplay() {
+    if (pendingOperatorDisplay) pendingOperatorCount = 1
+    pendingOperatorDisplay = undefined
+  }
+
+  function displayLinewiseOperation(span: VimSpan | null): VimOperatorResult {
+    if (!span) return { span: null, register: null }
+    const text = input.textarea().plainText.slice(span.start, span.end)
+    return { span, register: { text: text.endsWith("\n") ? text.slice(0, -1) : text, linewise: true } }
+  }
+
+  function visualLineMotionOperator(key: string, operation: VimOperator): boolean {
+    const direction = key === "j" || key === "down" ? "down" : key === "k" || key === "up" ? "up" : undefined
+    if (!direction) return false
+
+    const count = takeOperatorCount()
+    const result = () => {
+      const textarea = input.textarea()
+      const cursor = textarea.cursorOffset
+      const view = textarea.editorView as { getVisualCursor?: () => { visualCol: number } }
+      moveDisplayVertical(direction, count, view.getVisualCursor?.().visualCol)
+      const target = textarea.cursorOffset
+      textarea.cursorOffset = cursor
+
+      if (target === cursor) return charwiseOperation(null)
+
+      const start = Math.min(cursor, target)
+      const end = Math.max(cursor, target)
+      const sameColumnAtLineStart =
+        lineStartOffset(textarea.plainText, cursor) === cursor && lineStartOffset(textarea.plainText, target) === target
+      return sameColumnAtLineStart ? displayLinewiseOperation({ start, end }) : charwiseOperation({ start, end })
+    }
+
+    if (operation === "y") {
+      const yanked = result()
+      applyOperatorYank(yanked)
+      if (yanked.span) input.textarea().cursorOffset = yanked.span.start
+      return true
+    }
+
+    if (operation === "c") {
+      const initial = result()
+      if (!initial.span && !initial.register) {
+        input.state.clearPending()
+        return true
+      }
+      if (!initial.register?.linewise || !initial.span) {
+        applyOperatorEdit(result, operation)
+        return true
+      }
+
+      begin(() => {
+        const next = result()
+        if (!next.span && !next.register) {
+          input.state.clearPending()
+          return false
+        }
+        if (!next.span) {
+          if (next.register) setRegister(next.register)
+          input.state.clearPending()
+          input.state.setMode("insert")
+          return true
+        }
+        const end = input.textarea().plainText[next.span.end - 1] === "\n" ? next.span.end - 1 : next.span.end
+        if (end > next.span.start) deleteSpan(input.textarea(), { start: next.span.start, end })
+        if (next.register) setRegister(next.register)
+        input.state.clearPending()
+        input.state.setMode("insert")
+        return true
+      })
+      return true
+    }
+
+    applyOperatorResult(result, operation)
+    return true
+  }
+
   function verticalMotionOperator(event: VimEvent, key: string, operation: VimOperator): boolean {
     const direction = key === "j" || key === "down" ? "down" : key === "k" || key === "up" ? "up" : undefined
     if (!direction || event.shift || hasModifier(event)) return false
@@ -881,8 +959,22 @@ export function createVimHandler(input: {
 
     const scroll = vimScroll(event)
     if (scroll) {
+      clearPendingOperatorDisplay()
       input.state.clearPending()
       input.scroll(scroll)
+      event.preventDefault()
+      return true
+    }
+
+    const pendingForDisplay = input.state.pending()
+    if (
+      (pendingForDisplay === "c" || pendingForDisplay === "d" || pendingForDisplay === "y") &&
+      key === "g" &&
+      !event.shift &&
+      !hasModifier(event)
+    ) {
+      pendingOperatorDisplay = pendingForDisplay
+      input.state.setPending("g")
       event.preventDefault()
       return true
     }
@@ -894,16 +986,24 @@ export function createVimHandler(input: {
       !event.shift &&
       !hasModifier(event)
     ) {
-      const direction = key === "j" || key === "down" ? "down" : "up"
-      const count = takeCount()
-      const view = input.textarea().editorView as { getVisualCursor?: () => { visualCol: number } }
-      visualWantedColumn ??= view.getVisualCursor?.().visualCol
-      input.state.clearPending()
-      clearWantedColumn()
-      moveDisplayVertical(direction, count, visualWantedColumn)
+      const operation = pendingOperatorDisplay
+      pendingOperatorDisplay = undefined
+      if (operation) {
+        visualLineMotionOperator(key, operation)
+      } else {
+        const direction = key === "j" || key === "down" ? "down" : "up"
+        const count = takeCount()
+        const view = input.textarea().editorView as { getVisualCursor?: () => { visualCol: number } }
+        visualWantedColumn ??= view.getVisualCursor?.().visualCol
+        input.state.clearPending()
+        clearWantedColumn()
+        moveDisplayVertical(direction, count, visualWantedColumn)
+      }
       event.preventDefault()
       return true
     }
+
+    if (input.state.pending() === "g") clearPendingOperatorDisplay()
 
     const jump = vimJump(event, input.state)
     if (jump.handled) {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -2994,6 +2994,153 @@ describe("vim motion handler", () => {
     expect(ctx.state.register()).toEqual({ text: "two\nthree\nfour", linewise: true })
   })
 
+  test("dgj deletes display-line motion charwise", () => {
+    const ctx = createHandler("abc\ndef\nghi")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    const motion = createEvent("j")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+
+    expect(ctx.textarea.plainText).toBe("aef\nghi")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "bc\nd", linewise: false })
+  })
+
+  test("dgk deletes display-line motion charwise backward", () => {
+    const ctx = createHandler("abc\ndef\nghi")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    const motion = createEvent("k")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+
+    expect(ctx.textarea.plainText).toBe("aef\nghi")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "bc\nd", linewise: false })
+  })
+
+  test("ygk yanks display-line motion charwise and moves to target", () => {
+    const ctx = createHandler("abc\ndef\nghi")
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    const motion = createEvent("k")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+
+    expect(ctx.textarea.plainText).toBe("abc\ndef\nghi")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "bc\nd", linewise: false })
+  })
+
+  test("ygj yanks display-line motion linewise at line start", () => {
+    const ctx = createHandler("aa\nbb\ncc")
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.textarea.plainText).toBe("aa\nbb\ncc")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.register()).toEqual({ text: "aa", linewise: true })
+  })
+
+  test("cgj changes display-line motion linewise at line start", () => {
+    const ctx = createHandler("aa\nbb\ncc")
+
+    ctx.handler.handleKey(createEvent("c").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    const motion = createEvent("j")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+
+    expect(ctx.textarea.plainText).toBe("\nbb\ncc")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "aa", linewise: true })
+  })
+
+  test("cgj changes display-line motion charwise", () => {
+    const ctx = createHandler("abc\ndef\nghi")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("c").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    const motion = createEvent("j")
+    expect(ctx.handler.handleKey(motion.event)).toBe(true)
+    expect(motion.prevented()).toBe(true)
+
+    expect(ctx.textarea.plainText).toBe("aef\nghi")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "bc\nd", linewise: false })
+  })
+
+  test("operator display-line motions support counts", () => {
+    const ctx = createHandler("a\nb\nc\nd")
+
+    ctx.handler.handleKey(createEvent("2").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.textarea.plainText).toBe("c\nd")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "a\nb", linewise: true })
+  })
+
+  test("operator-pending counts apply to display-line motions", () => {
+    const ctx = createHandler("a\nb\nc\nd")
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("2").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.textarea.plainText).toBe("c\nd")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "a\nb", linewise: true })
+  })
+
+  test("operator display-line motions support arrow aliases", () => {
+    const ctx = createHandler("abc\ndef")
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("down").event)
+
+    expect(ctx.textarea.plainText).toBe("aef")
+    expect(ctx.state.register()).toEqual({ text: "bc\nd", linewise: false })
+  })
+
+  test("cancelled operator display-line motion clears pending count", () => {
+    const ctx = createHandler("a\nb\nc\nd")
+
+    ctx.handler.handleKey(createEvent("2").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("escape").event)
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.textarea.plainText).toBe("c\nd")
+    expect(ctx.state.register()).toEqual({ text: "a\nb", linewise: true })
+  })
+
   test("yk yanks previous and current line", () => {
     const ctx = createHandler("one\ntwo\nthree\nfour")
     ctx.textarea.cursorOffset = 11
@@ -7104,6 +7251,35 @@ describe("vim dot repeat", () => {
     press(ctx, ".")
     expect(ctx.textarea.plainText).toBe("")
     expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("dot repeats dgj from the current cursor", () => {
+    const ctx = createHandler("aa\nbb\ncc\ndd")
+
+    press(ctx, "d")
+    press(ctx, "g")
+    press(ctx, "j")
+    expect(ctx.textarea.plainText).toBe("bb\ncc\ndd")
+
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("cc\ndd")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("dot repeats cgj inserted text from the current cursor", () => {
+    const ctx = createHandler("aa\nbb\ncc")
+
+    press(ctx, "c")
+    press(ctx, "g")
+    press(ctx, "j")
+    ctx.textarea.insertText("X")
+    press(ctx, "escape")
+    expect(ctx.textarea.plainText).toBe("X\nbb\ncc")
+
+    ctx.textarea.cursorOffset = 2
+    press(ctx, ".")
+    expect(ctx.textarea.plainText).toBe("X\nX\ncc")
+    expect(ctx.textarea.cursorOffset).toBe(2)
   })
 
   test("dot repeat of c% no-ops when the repeated motion fails", () => {

--- a/packages/tui/test/vim-visual-line-motions.test.ts
+++ b/packages/tui/test/vim-visual-line-motions.test.ts
@@ -45,6 +45,7 @@ async function createWrappedHandler(text: string) {
   })
   return {
     textarea: setup.textarea,
+    state,
     handler,
     [Symbol.dispose]() {
       disposeRoot()
@@ -133,5 +134,56 @@ describe("visual line motions (gj/gk)", () => {
     ctx.handler.handleKey(createEvent("g"))
     ctx.handler.handleKey(createEvent("j"))
     expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(10)
+  })
+
+  test("dgj deletes one wrapped display row charwise", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+
+    ctx.handler.handleKey(createEvent("d"))
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("j"))
+
+    expect(ctx.textarea.plainText).toBe("BBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.register()).toEqual({ text: "AAAAAAAAAAAAAAAAAAAA", linewise: false })
+  })
+
+  test("dgk deletes one wrapped display row charwise backward", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+    ctx.textarea.cursorOffset = 40
+
+    ctx.handler.handleKey(createEvent("d"))
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("k"))
+
+    expect(ctx.textarea.plainText).toBe("AAAAAAAAAAAAAAAAAAAACCCCCCCCCCCCCCCCCCCC")
+    expect(ctx.textarea.cursorOffset).toBe(20)
+    expect(ctx.state.register()).toEqual({ text: "BBBBBBBBBBBBBBBBBBBB", linewise: false })
+  })
+
+  test("ygk yanks one wrapped display row charwise", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+    ctx.textarea.cursorOffset = 40
+
+    ctx.handler.handleKey(createEvent("y"))
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("k"))
+
+    expect(ctx.textarea.plainText).toBe("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+    expect(ctx.textarea.cursorOffset).toBe(20)
+    expect(ctx.state.register()).toEqual({ text: "BBBBBBBBBBBBBBBBBBBB", linewise: false })
+  })
+
+  test("cgj changes one wrapped display row charwise", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+
+    ctx.handler.handleKey(createEvent("c"))
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("j"))
+
+    expect(ctx.textarea.plainText).toBe("BBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.register()).toEqual({ text: "AAAAAAAAAAAAAAAAAAAA", linewise: false })
   })
 })


### PR DESCRIPTION
Part of #216

Adds operator pending support for prompt display line motions: `dgj`/`dgk`, `ygj`/`ygk`, and `cgj`/`cgk` (including arrow aliases and counts).
