### PR TITLE
feat(prompt): support display-line horizontal motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Toggle via command palette > `Toggle vim mode`.
 | ------------------------------ | ---------------------------------------------------------- |
 | Character / word               | `h`, `j`, `k`, `l`, `w`, `b`, `e`, `W`, `B`, `E`           |
 | Line / buffer                  | `0`, `^`, `_`, `$`, `gg`, `G`                              |
-| Display line                   | `gj`, `gk`, `g<Down>`, `g<Up>`                             |
+| Display line                   | `gj`, `gk`, `g<Down>`, `g<Up>`, `g0`, `g^`, `g$`            |
 | Matching / paragraph           | `%`, `{`, `}`                                              |
 | Find / till                    | `f`, `F`, `t`, `T`, `;`, `,`                               |
 | Scroll                         | `Ctrl+e`, `Ctrl+y`, `Ctrl+d`, `Ctrl+u`, `Ctrl+f`, `Ctrl+b` |

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -36,7 +36,10 @@ import {
   moveLineBeginning,
   moveLineDown,
   moveLineUp,
+  moveVisualFirstNonWhitespace,
+  moveVisualLineBeginning,
   moveVisualLineDown,
+  moveVisualLineEnd,
   moveVisualLineUp,
   moveMatchingBracket,
   moveNextParagraph,
@@ -125,6 +128,8 @@ function normalizedKeyName(event: VimKeyLike) {
   )
     return text
   if (event.shift) {
+    if (event.name === "4") return "$"
+    if (event.name === "6") return "^"
     if (event.name === "9") return "("
     if (event.name === "0") return ")"
     if (event.name === "[") return "{"
@@ -546,6 +551,14 @@ export function createVimHandler(input: {
       clampCursorToLine(input.textarea())
       if (column !== undefined) alignVisualColumn(input.textarea(), column)
     })
+  }
+
+  function moveDisplayHorizontal(key: string, count: number) {
+    const textarea = input.textarea()
+    if (key === "$") repeatCount(count - 1, () => moveDisplayVertical("down", 1, undefined))
+    if (key === "0") moveVisualLineBeginning(textarea)
+    else if (key === "^") moveVisualFirstNonWhitespace(textarea)
+    else moveVisualLineEnd(textarea)
   }
 
   function lineMotionAnchor(direction: "up" | "down", count: number) {
@@ -980,27 +993,32 @@ export function createVimHandler(input: {
     }
 
     // Must run before vimJump, which clears pending g on non-g keys.
-    if (
-      input.state.pending() === "g" &&
-      (key === "j" || key === "k" || key === "down" || key === "up") &&
-      !event.shift &&
-      !hasModifier(event)
-    ) {
+    if (input.state.pending() === "g" && !hasModifier(event)) {
       const operation = pendingOperatorDisplay
-      pendingOperatorDisplay = undefined
-      if (operation) {
-        visualLineMotionOperator(key, operation)
-      } else {
-        const direction = key === "j" || key === "down" ? "down" : "up"
+      if ((key === "j" || key === "k" || key === "down" || key === "up") && !event.shift) {
+        pendingOperatorDisplay = undefined
+        if (operation) {
+          visualLineMotionOperator(key, operation)
+        } else {
+          const direction = key === "j" || key === "down" ? "down" : "up"
+          const count = takeCount()
+          const view = input.textarea().editorView as { getVisualCursor?: () => { visualCol: number } }
+          visualWantedColumn ??= view.getVisualCursor?.().visualCol
+          input.state.clearPending()
+          clearWantedColumn()
+          moveDisplayVertical(direction, count, visualWantedColumn)
+        }
+        event.preventDefault()
+        return true
+      }
+      if (!operation && ((key === "0" && !event.shift) || key === "^" || key === "$")) {
         const count = takeCount()
-        const view = input.textarea().editorView as { getVisualCursor?: () => { visualCol: number } }
-        visualWantedColumn ??= view.getVisualCursor?.().visualCol
         input.state.clearPending()
         clearWantedColumn()
-        moveDisplayVertical(direction, count, visualWantedColumn)
+        moveDisplayHorizontal(key, count)
+        event.preventDefault()
+        return true
       }
-      event.preventDefault()
-      return true
     }
 
     if (input.state.pending() === "g") clearPendingOperatorDisplay()

--- a/packages/tui/src/component/vim/vim-motions.ts
+++ b/packages/tui/src/component/vim/vim-motions.ts
@@ -247,6 +247,74 @@ export function moveVisualLineDown(textarea: TextareaRenderable) {
   moveLineDown(textarea)
 }
 
+function setVisualOffset(textarea: TextareaRenderable, offset: number) {
+  const view = textarea.editorView as { setCursorByOffset?: (offset: number) => void }
+  if (typeof view?.setCursorByOffset === "function") view.setCursorByOffset(offset)
+  else textarea.cursorOffset = offset
+}
+
+function visualRow(textarea: TextareaRenderable) {
+  const view = textarea.editorView as { getVisualCursor?: () => { visualRow: number } }
+  return typeof view?.getVisualCursor === "function" ? view.getVisualCursor().visualRow : undefined
+}
+
+export function visualLineStart(textarea: TextareaRenderable) {
+  const row = visualRow(textarea)
+  if (row === undefined) return lineStart(textarea.plainText, textarea.cursorOffset)
+
+  let offset = textarea.cursorOffset
+  while (offset > lineStart(textarea.plainText, offset)) {
+    setVisualOffset(textarea, offset - 1)
+    const moved = textarea.cursorOffset
+    if (moved === offset) return offset
+    if (visualRow(textarea) !== row) {
+      setVisualOffset(textarea, offset)
+      return offset
+    }
+    offset = moved
+  }
+  return offset
+}
+
+export function visualLineEnd(textarea: TextareaRenderable) {
+  const row = visualRow(textarea)
+  if (row === undefined) return lineLast(textarea.plainText, textarea.cursorOffset)
+
+  let offset = textarea.cursorOffset
+  while (offset < lineLast(textarea.plainText, offset)) {
+    setVisualOffset(textarea, offset + 1)
+    const moved = textarea.cursorOffset
+    if (moved === offset) return offset
+    if (visualRow(textarea) !== row) {
+      setVisualOffset(textarea, offset)
+      return offset
+    }
+    offset = moved
+  }
+  return offset
+}
+
+export function moveVisualLineBeginning(textarea: TextareaRenderable) {
+  setVisualOffset(textarea, visualLineStart(textarea))
+}
+
+export function moveVisualFirstNonWhitespace(textarea: TextareaRenderable) {
+  const start = visualLineStart(textarea)
+  const end = visualLineEnd(textarea)
+  for (let offset = start; offset <= end; offset++) {
+    const char = textarea.plainText[offset]
+    if (char && !/\s/.test(char)) {
+      setVisualOffset(textarea, offset)
+      return
+    }
+  }
+  setVisualOffset(textarea, start)
+}
+
+export function moveVisualLineEnd(textarea: TextareaRenderable) {
+  setVisualOffset(textarea, visualLineEnd(textarea))
+}
+
 export function moveMatchingBracket(textarea: TextareaRenderable) {
   const target = matchingBracketTarget(textarea.plainText, textarea.cursorOffset)
   if (target === null) return false

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -5849,6 +5849,149 @@ describe("vim motion handler", () => {
     expect(ctx.state.count()).toBe("")
   })
 
+  test("g0, g^, and g$ move within the current display line", () => {
+    const text = "  abc def ghi"
+    const ctx = createHandler(text)
+    const width = 6
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+
+    ctx.textarea.cursorOffset = 8
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("0").event)
+    expect(ctx.textarea.cursorOffset).toBe(6)
+
+    ctx.textarea.cursorOffset = 6
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("^").event)
+    expect(ctx.textarea.cursorOffset).toBe(6)
+
+    ctx.textarea.cursorOffset = 8
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("$").event)
+    expect(ctx.textarea.cursorOffset).toBe(11)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("g^ falls back to the display-line start when the display line is blank", () => {
+    const text = "      abc"
+    const ctx = createHandler(text)
+    const width = 6
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+
+    ctx.textarea.cursorOffset = 3
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("^").event)
+
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("g^ and g$ handle shifted base-key events", () => {
+    const text = "  abc def ghi"
+    const ctx = createHandler(text)
+    const width = 6
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+
+    ctx.textarea.cursorOffset = 1
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("6", { shift: true }).event)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+
+    ctx.textarea.cursorOffset = 8
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("4", { shift: true }).event)
+    expect(ctx.textarea.cursorOffset).toBe(11)
+  })
+
+  test("counted g$ moves to the end of a later display line", () => {
+    const text = "aaa\nbbb\nccc"
+    const ctx = createHandler(text)
+
+    ctx.handler.handleKey(createEvent("2").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("$").event)
+
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 1, 2))
+    expect(ctx.state.count()).toBe("")
+  })
+
+  test("g$ in visual mode extends the selection", () => {
+    const text = "abc def ghi"
+    const ctx = createHandler(text)
+    const width = 6
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("$").event)
+
+    expect(ctx.state.mode()).toBe("visual")
+    expect(ctx.textarea.cursorOffset).toBe(5)
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 1, end: 6 })
+  })
+
+  test("pending operator g$ does not run as a display-line motion", () => {
+    const text = "abc def ghi"
+    const ctx = createHandler(text)
+    const width = 6
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+    ctx.textarea.cursorOffset = 1
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("$").event)
+
+    expect(ctx.textarea.plainText).toBe(text)
+    expect(ctx.textarea.cursorOffset).toBe(text.length - 1)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toBeNull()
+  })
+
   test("repeated gj preserves desired visual column across short lines", () => {
     const text = "abcd\ne\nijkl"
     const ctx = createHandler(text)

--- a/packages/tui/test/vim-visual-line-motions.test.ts
+++ b/packages/tui/test/vim-visual-line-motions.test.ts
@@ -3,7 +3,13 @@ import { createRoot } from "solid-js"
 import { createTestRenderer } from "@opentui/core/testing"
 import { TextareaRenderable } from "@opentui/core"
 import { createVimHandler, type VimEvent } from "../src/component/vim/vim-handler"
-import { moveVisualLineDown, moveVisualLineUp } from "../src/component/vim/vim-motions"
+import {
+  moveVisualFirstNonWhitespace,
+  moveVisualLineBeginning,
+  moveVisualLineDown,
+  moveVisualLineEnd,
+  moveVisualLineUp,
+} from "../src/component/vim/vim-motions"
 import { createVimState } from "../src/component/vim/vim-state"
 
 const WRAPPED = "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10"
@@ -185,5 +191,46 @@ describe("visual line motions (gj/gk)", () => {
     expect(ctx.textarea.cursorOffset).toBe(0)
     expect(ctx.state.mode()).toBe("insert")
     expect(ctx.state.register()).toEqual({ text: "AAAAAAAAAAAAAAAAAAAA", linewise: false })
+  })
+
+  test("display-line horizontal helpers stay on the current wrapped row", async () => {
+    using ctx = await createWrappedTextarea("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBB")
+    ctx.textarea.cursorOffset = 24
+
+    moveVisualLineBeginning(ctx.textarea)
+    expect(ctx.textarea.cursorOffset).toBe(20)
+    expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(0)
+
+    moveVisualLineEnd(ctx.textarea)
+    expect(ctx.textarea.cursorOffset).toBe(39)
+    expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(19)
+  })
+
+  test("display-line first non-whitespace skips blanks on the current wrapped row", async () => {
+    using ctx = await createWrappedTextarea("  AAAAAAAAAAAAAAAAAA")
+    ctx.textarea.cursorOffset = 1
+
+    moveVisualFirstNonWhitespace(ctx.textarea)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+  })
+
+  test("g0, g^, and g$ use wrapped display rows", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBB")
+
+    ctx.textarea.cursorOffset = 24
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("0"))
+    expect(ctx.textarea.cursorOffset).toBe(20)
+
+    ctx.textarea.cursorOffset = 24
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("$"))
+    expect(ctx.textarea.cursorOffset).toBe(39)
+
+    using indented = await createWrappedHandler("  AAAAAAAAAAAAAAAAAA")
+    indented.textarea.cursorOffset = 1
+    indented.handler.handleKey(createEvent("g"))
+    indented.handler.handleKey(createEvent("^"))
+    expect(indented.textarea.cursorOffset).toBe(2)
   })
 })


### PR DESCRIPTION
Part of #216 

Adds prompt display-line horizontal motions: `g0`, `g^`, and `g$`, including count support for `g$`.
