### PR TITLE
feat(prompt): support operators for horizontal display-line motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,33 +49,34 @@ Toggle via command palette > `Toggle vim mode`.
 
 > Unicode word boundaries are not supported.
 
-| Category                       | Keys                                                       |
-| ------------------------------ | ---------------------------------------------------------- |
-| Character / word               | `h`, `j`, `k`, `l`, `w`, `b`, `e`, `W`, `B`, `E`           |
-| Line / buffer                  | `0`, `^`, `_`, `$`, `gg`, `G`                              |
-| Display line                   | `gj`, `gk`, `g<Down>`, `g<Up>`, `g0`, `g^`, `g$`            |
-| Matching / paragraph           | `%`, `{`, `}`                                              |
-| Find / till                    | `f`, `F`, `t`, `T`, `;`, `,`                               |
-| Scroll                         | `Ctrl+e`, `Ctrl+y`, `Ctrl+d`, `Ctrl+u`, `Ctrl+f`, `Ctrl+b` |
-| Insert / replace               | `i`, `I`, `a`, `A`, `o`, `O`, `R`                          |
-| Character / line edit          | `r`, `x`, `~`, `s`, `S`, `J`, `C`, `D`, `dd`, `cc`         |
-| Word changes                   | `cw`, `cb`, `ce`, `cW`, `cE`, `ciw`, `caw`, `ciW`, `caW`   |
-| Word deletes                   | `dw`, `db`, `de`, `dW`, `dE`, `diw`, `daw`, `diW`, `daW`   |
-| Quote changes                  | `ci"`, `ca"`, `ci'`, `ca'`, ``ci` ``, ``ca` ``             |
-| Quote deletes                  | `di"`, `da"`, `di'`, `da'`, ``di` ``, ``da` ``             |
-| Bracket changes                | `ci(`, `ca(`, `ci[`, `ca[`, `ci{`, `ca{`, `ci<`, `ca<`     |
-| Bracket deletes                | `di(`, `da(`, `di[`, `da[`, `di{`, `da{`, `di<`, `da<`     |
-| Find / till operators          | `cf`, `cF`, `ct`, `cT`, `df`, `dF`, `dt`, `dT`             |
-| Matching / paragraph operators | `c%`, `d%`, `c}`, `c{`, `d}`, `d{`                         |
-| Line boundary operators        | `c0`, `c^`, `c$`, `d0`, `d^`, `d$`, `y0`, `y^`, `y$`       |
-| Line / word yanks              | `yy`, `yw`, `ye`, `yW`, `yE`, `yiw`, `yaw`, `yiW`, `yaW`   |
-| Quote yanks                    | `yi"`, `ya"`, `yi'`, `ya'`, ``yi` ``, ``ya` ``             |
-| Bracket yanks                  | `yi(`, `ya(`, `yi[`, `ya[`, `yi{`, `ya{`, `yi<`, `ya<`     |
-| Matching / paragraph yanks     | `y%`, `y}`, `y{`                                           |
-| Put / undo / repeat            | `p`, `P`, `u`, `Ctrl+r`, `.`                               |
-| Visual selection               | `v`, `V`                                                   |
-| Chat history search            | `/`, `?`                                                   |
-| Commands                       | `:`, `:q`                                                  |
+| Category                       | Keys                                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Character / word               | `h`, `j`, `k`, `l`, `w`, `b`, `e`, `W`, `B`, `E`                                                        |
+| Line / buffer                  | `0`, `^`, `_`, `$`, `gg`, `G`                                                                           |
+| Display line                   | `gj`, `gk`, `g<Down>`, `g<Up>`, `g0`, `g^`, `g$`                                                        |
+| Matching / paragraph           | `%`, `{`, `}`                                                                                           |
+| Find / till                    | `f`, `F`, `t`, `T`, `;`, `,`                                                                            |
+| Scroll                         | `Ctrl+e`, `Ctrl+y`, `Ctrl+d`, `Ctrl+u`, `Ctrl+f`, `Ctrl+b`                                              |
+| Insert / replace               | `i`, `I`, `a`, `A`, `o`, `O`, `R`                                                                       |
+| Character / line edit          | `r`, `x`, `~`, `s`, `S`, `J`, `C`, `D`, `dd`, `cc`                                                      |
+| Word changes                   | `cw`, `cb`, `ce`, `cW`, `cE`, `ciw`, `caw`, `ciW`, `caW`                                                |
+| Word deletes                   | `dw`, `db`, `de`, `dW`, `dE`, `diw`, `daw`, `diW`, `daW`                                                |
+| Quote changes                  | `ci"`, `ca"`, `ci'`, `ca'`, ``ci` ``, ``ca` ``                                                          |
+| Quote deletes                  | `di"`, `da"`, `di'`, `da'`, ``di` ``, ``da` ``                                                          |
+| Bracket changes                | `ci(`, `ca(`, `ci[`, `ca[`, `ci{`, `ca{`, `ci<`, `ca<`                                                  |
+| Bracket deletes                | `di(`, `da(`, `di[`, `da[`, `di{`, `da{`, `di<`, `da<`                                                  |
+| Find / till operators          | `cf`, `cF`, `ct`, `cT`, `df`, `dF`, `dt`, `dT`                                                          |
+| Matching / paragraph operators | `c%`, `d%`, `c}`, `c{`, `d}`, `d{`                                                                      |
+| Line boundary operators        | `c0`, `c^`, `c$`, `d0`, `d^`, `d$`, `y0`, `y^`, `y$`                                                    |
+| Display line operators         | `cgj`, `cgk`, `cg0`, `cg^`, `cg$`, `dgj`, `dgk`, `dg0`, `dg^`, `dg$`, `ygj`, `ygk`, `yg0`, `yg^`, `yg$` |
+| Line / word yanks              | `yy`, `yw`, `ye`, `yW`, `yE`, `yiw`, `yaw`, `yiW`, `yaW`                                                |
+| Quote yanks                    | `yi"`, `ya"`, `yi'`, `ya'`, ``yi` ``, ``ya` ``                                                          |
+| Bracket yanks                  | `yi(`, `ya(`, `yi[`, `ya[`, `yi{`, `ya{`, `yi<`, `ya<`                                                  |
+| Matching / paragraph yanks     | `y%`, `y}`, `y{`                                                                                        |
+| Put / undo / repeat            | `p`, `P`, `u`, `Ctrl+r`, `.`                                                                            |
+| Visual selection               | `v`, `V`                                                                                                |
+| Chat history search            | `/`, `?`                                                                                                |
+| Commands                       | `:`, `:q`                                                                                               |
 
 Numeric count prefixes are supported for motions and common operators.
 

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -595,6 +595,37 @@ export function createVimHandler(input: {
     return { span, register: { text: text.endsWith("\n") ? text.slice(0, -1) : text, linewise: true } }
   }
 
+  function visualLineHorizontalMotionOperator(key: string, operation: VimOperator): boolean {
+    const count = takeOperatorCount()
+    const result = () => {
+      const textarea = input.textarea()
+      const cursor = textarea.cursorOffset
+      moveDisplayHorizontal(key, key === "$" ? count : 1)
+      const target = textarea.cursorOffset
+      textarea.cursorOffset = cursor
+
+      if (key === "$") {
+        const end = textarea.plainText[target] && textarea.plainText[target] !== "\n" ? target + 1 : target
+        return charwiseOperation(end > cursor ? { start: cursor, end } : null)
+      }
+
+      if (target === cursor) return charwiseOperation(null)
+
+      const span = { start: Math.min(cursor, target), end: Math.max(cursor, target) }
+      return charwiseOperation(span.end > span.start ? span : null)
+    }
+
+    if (operation === "y") {
+      const yanked = result()
+      applyOperatorYank(yanked)
+      if (yanked.span) input.textarea().cursorOffset = yanked.span.start
+      return true
+    }
+
+    applyOperatorResult(result, operation)
+    return true
+  }
+
   function visualLineMotionOperator(key: string, operation: VimOperator): boolean {
     const direction = key === "j" || key === "down" ? "down" : key === "k" || key === "up" ? "up" : undefined
     if (!direction) return false
@@ -987,7 +1018,7 @@ export function createVimHandler(input: {
       !hasModifier(event)
     ) {
       pendingOperatorDisplay = pendingForDisplay
-      input.state.setPending("g")
+      input.state.setPending("g", pendingForDisplay + "g")
       event.preventDefault()
       return true
     }
@@ -1011,11 +1042,16 @@ export function createVimHandler(input: {
         event.preventDefault()
         return true
       }
-      if (!operation && ((key === "0" && !event.shift) || key === "^" || key === "$")) {
-        const count = takeCount()
-        input.state.clearPending()
-        clearWantedColumn()
-        moveDisplayHorizontal(key, count)
+      if ((key === "0" && !event.shift) || key === "^" || key === "$") {
+        pendingOperatorDisplay = undefined
+        if (operation) {
+          visualLineHorizontalMotionOperator(key, operation)
+        } else {
+          const count = takeCount()
+          input.state.clearPending()
+          clearWantedColumn()
+          moveDisplayHorizontal(key, count)
+        }
         event.preventDefault()
         return true
       }

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -3010,6 +3010,18 @@ describe("vim motion handler", () => {
     expect(ctx.state.register()).toEqual({ text: "bc\nd", linewise: false })
   })
 
+  test("operator display-line pending indicator shows full command", () => {
+    const ctx = createHandler("abc\ndef")
+
+    ctx.handler.handleKey(createEvent("d").event)
+    expect(ctx.state.pending()).toBe("d")
+    expect(ctx.state.pendingDisplay()).toBe("")
+
+    ctx.handler.handleKey(createEvent("g").event)
+    expect(ctx.state.pending()).toBe("g")
+    expect(ctx.state.pendingDisplay()).toBe("dg")
+  })
+
   test("dgk deletes display-line motion charwise backward", () => {
     const ctx = createHandler("abc\ndef\nghi")
     ctx.textarea.cursorOffset = 5
@@ -5966,10 +5978,10 @@ describe("vim motion handler", () => {
     expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 1, end: 6 })
   })
 
-  test("pending operator g$ does not run as a display-line motion", () => {
-    const text = "abc def ghi"
+  test("dg$ deletes through display-line end charwise", () => {
+    const text = "abcdefghi"
     const ctx = createHandler(text)
-    const width = 6
+    const width = 3
     ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
       visualRow: Math.floor(ctx.textarea.cursorOffset / width),
       visualCol: ctx.textarea.cursorOffset % width,
@@ -5986,10 +5998,176 @@ describe("vim motion handler", () => {
     ctx.handler.handleKey(createEvent("g").event)
     ctx.handler.handleKey(createEvent("$").event)
 
-    expect(ctx.textarea.plainText).toBe(text)
-    expect(ctx.textarea.cursorOffset).toBe(text.length - 1)
+    expect(ctx.textarea.plainText).toBe("adefghi")
+    expect(ctx.textarea.cursorOffset).toBe(1)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "bc", linewise: false })
+  })
+
+  test("horizontal display-line $ operators include current char at display-line end", () => {
+    const setup = () => {
+      const ctx = createHandler("abc\ndef")
+      const width = 3
+      ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+        visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+        visualCol: ctx.textarea.cursorOffset % width,
+        logicalRow: 0,
+        logicalCol: ctx.textarea.cursorOffset,
+        offset: ctx.textarea.cursorOffset,
+      })
+      ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+        ctx.textarea.cursorOffset = offset
+      }
+      ctx.textarea.cursorOffset = 2
+      return ctx
+    }
+
+    const deleted = setup()
+    deleted.handler.handleKey(createEvent("d").event)
+    deleted.handler.handleKey(createEvent("g").event)
+    deleted.handler.handleKey(createEvent("$").event)
+    expect(deleted.textarea.plainText).toBe("ab\ndef")
+    expect(deleted.state.register()).toEqual({ text: "c", linewise: false })
+
+    const yanked = setup()
+    yanked.handler.handleKey(createEvent("y").event)
+    yanked.handler.handleKey(createEvent("g").event)
+    yanked.handler.handleKey(createEvent("$").event)
+    expect(yanked.textarea.plainText).toBe("abc\ndef")
+    expect(yanked.textarea.cursorOffset).toBe(2)
+    expect(yanked.state.register()).toEqual({ text: "c", linewise: false })
+
+    const changed = setup()
+    changed.handler.handleKey(createEvent("c").event)
+    changed.handler.handleKey(createEvent("g").event)
+    changed.handler.handleKey(createEvent("$").event)
+    expect(changed.textarea.plainText).toBe("ab\ndef")
+    expect(changed.textarea.cursorOffset).toBe(2)
+    expect(changed.state.mode()).toBe("insert")
+    expect(changed.state.register()).toEqual({ text: "c", linewise: false })
+  })
+
+  test("dg$ on an empty display line is a no-op", () => {
+    const ctx = createHandler("abc\n\ndef")
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: ctx.textarea.cursorOffset,
+      visualCol: 0,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+    ctx.textarea.cursorOffset = 4
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("$").event)
+
+    expect(ctx.textarea.plainText).toBe("abc\n\ndef")
+    expect(ctx.textarea.cursorOffset).toBe(4)
     expect(ctx.state.pending()).toBe("")
     expect(ctx.state.register()).toBeNull()
+  })
+
+  test("dg0 deletes backward to display-line start charwise", () => {
+    const text = "abcdefghi"
+    const ctx = createHandler(text)
+    const width = 3
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+    ctx.textarea.cursorOffset = 4
+
+    ctx.handler.handleKey(createEvent("d").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("0").event)
+
+    expect(ctx.textarea.plainText).toBe("abcefghi")
+    expect(ctx.textarea.cursorOffset).toBe(3)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "d", linewise: false })
+  })
+
+  test("yg0 yanks backward to display-line start charwise", () => {
+    const text = "abcdefghi"
+    const ctx = createHandler(text)
+    const width = 3
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+    ctx.textarea.cursorOffset = 5
+
+    ctx.handler.handleKey(createEvent("y").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("0").event)
+
+    expect(ctx.textarea.plainText).toBe(text)
+    expect(ctx.textarea.cursorOffset).toBe(3)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "de", linewise: false })
+  })
+
+  test("cg^ changes backward to display-line first nonblank charwise", () => {
+    const text = "abc  def"
+    const ctx = createHandler(text)
+    const width = 5
+    ;(ctx.textarea as any).editorView.getVisualCursor = () => ({
+      visualRow: Math.floor(ctx.textarea.cursorOffset / width),
+      visualCol: ctx.textarea.cursorOffset % width,
+      logicalRow: 0,
+      logicalCol: ctx.textarea.cursorOffset,
+      offset: ctx.textarea.cursorOffset,
+    })
+    ;(ctx.textarea as any).editorView.setCursorByOffset = (offset: number) => {
+      ctx.textarea.cursorOffset = offset
+    }
+    ctx.textarea.cursorOffset = 7
+
+    ctx.handler.handleKey(createEvent("c").event)
+    ctx.handler.handleKey(createEvent("g").event)
+    ctx.handler.handleKey(createEvent("^").event)
+
+    expect(ctx.textarea.plainText).toBe("abc  f")
+    expect(ctx.textarea.cursorOffset).toBe(5)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.register()).toEqual({ text: "de", linewise: false })
+  })
+
+  test("horizontal display-line operators support counts", () => {
+    const first = createHandler("aaa\nbbb\nccc")
+    first.handler.handleKey(createEvent("2").event)
+    first.handler.handleKey(createEvent("d").event)
+    first.handler.handleKey(createEvent("g").event)
+    first.handler.handleKey(createEvent("$").event)
+
+    expect(first.textarea.plainText).toBe("\nccc")
+    expect(first.state.register()).toEqual({ text: "aaa\nbbb", linewise: false })
+
+    const second = createHandler("aaa\nbbb\nccc")
+    second.handler.handleKey(createEvent("d").event)
+    second.handler.handleKey(createEvent("2").event)
+    second.handler.handleKey(createEvent("g").event)
+    second.handler.handleKey(createEvent("$").event)
+
+    expect(second.textarea.plainText).toBe("\nccc")
+    expect(second.state.register()).toEqual({ text: "aaa\nbbb", linewise: false })
   })
 
   test("repeated gj preserves desired visual column across short lines", () => {

--- a/packages/tui/test/vim-visual-line-motions.test.ts
+++ b/packages/tui/test/vim-visual-line-motions.test.ts
@@ -233,4 +233,27 @@ describe("visual line motions (gj/gk)", () => {
     indented.handler.handleKey(createEvent("^"))
     expect(indented.textarea.cursorOffset).toBe(2)
   })
+
+  test("display-line horizontal operators use wrapped rows", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBB")
+    ctx.textarea.cursorOffset = 24
+
+    ctx.handler.handleKey(createEvent("d"))
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("0"))
+
+    expect(ctx.textarea.plainText).toBe("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBB")
+    expect(ctx.textarea.cursorOffset).toBe(20)
+    expect(ctx.state.register()).toEqual({ text: "BBBB", linewise: false })
+
+    using yank = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBB")
+    yank.textarea.cursorOffset = 24
+    yank.handler.handleKey(createEvent("y"))
+    yank.handler.handleKey(createEvent("g"))
+    yank.handler.handleKey(createEvent("$"))
+
+    expect(yank.textarea.plainText).toBe("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBB")
+    expect(yank.textarea.cursorOffset).toBe(24)
+    expect(yank.state.register()).toEqual({ text: "BBBBBBBBBBBBBBBB", linewise: false })
+  })
 })


### PR DESCRIPTION
Closes #216 

Adds prompt operator support for horizontal display-line motions: `dg0`, `dg^`, `dg$`, `yg0`, `yg^`, `yg$`, `cg0`, `cg^`,`cg$`
