### PR TITLE
feat(keymap): support normal mode scoped keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ Toggle via command palette > `Toggle minimal ui`.
 | `vim_langmap`                   | Map non-English keys or simple aliases   |
 | `vim_escape_sequence`           | Use a two-key escape sequence like `jk`  |
 
+### Mode-scoped keybinds
+
+Bind existing commands only in normal mode by nesting overrides under `vim.normal`:
+
+```json
+{
+  // Scroll with plain j/k
+  "keybinds": {
+    "vim.normal": {
+      "messages_line_down": "j",
+      "messages_line_up": "k"
+    }
+  }
+}
+```
+
 ### Prompt input height
 
 Configure prompt input height in `tui.json`:

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -71,12 +71,12 @@ function normalize(raw: Record<string, unknown>) {
 function dropUnknownKeybinds(input: Record<string, unknown>) {
   if (!isRecord(input.keybinds)) return input
 
-  const invalid = TuiKeybind.unknownKeys(input.keybinds)
-  if (!invalid.length) return input
+  const next = TuiKeybind.dropUnknown(input.keybinds)
+  if (JSON.stringify(next) === JSON.stringify(input.keybinds)) return input
 
   return {
     ...input,
-    keybinds: Object.fromEntries(Object.entries(input.keybinds).filter(([key]) => !invalid.includes(key))),
+    keybinds: next,
   }
 }
 

--- a/packages/tui/src/component/prompt/vim.ts
+++ b/packages/tui/src/component/prompt/vim.ts
@@ -6,7 +6,7 @@ import { useSync } from "../../context/sync"
 import { useDialog } from "../../ui/dialog"
 import { useToast } from "../../ui/toast"
 import { useTuiConfig } from "../../config"
-import { OPENCODE_COPY_MODE, useOpencodeKeymap, useOpencodeModeStack } from "../../keymap"
+import { OPENCODE_COPY_MODE, OPENCODE_VIM_MODE_KEY, useOpencodeKeymap, useOpencodeModeStack } from "../../keymap"
 import { useVimEnabled } from "../vim"
 import { createVimState, type VimMode, type VimRegister, type VimSnapshot } from "../vim/vim-state"
 import { createVimHandler, vimLangmapKeyName } from "../vim/vim-handler"
@@ -48,7 +48,12 @@ export function usePromptVim(opts: {
   let popCopyMode: (() => void) | undefined
   onCleanup(() => {
     popCopyMode?.()
+    keymap.setData(OPENCODE_VIM_MODE_KEY, undefined)
     if (vimEnabled()) lastVimMode = vimState.isCopy() ? "normal" : vimState.mode()
+  })
+
+  createEffect(() => {
+    keymap.setData(OPENCODE_VIM_MODE_KEY, vimEnabled() && opts.mode() === "normal" ? vimState.mode() : "insert")
   })
 
   createEffect(() => {

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -25,6 +25,7 @@ const BindingObject = Schema.StructWithRest(
 )
 
 const BindingItem = Schema.Union([Schema.String, KeyStroke, BindingObject])
+type BindingItem = Schema.Schema.Type<typeof BindingItem>
 export const BindingValueSchema = Schema.Union([
   Schema.Literal(false),
   Schema.Literal("none"),
@@ -249,14 +250,31 @@ Definitions.session_parent.default = "up,k"
 type KeybindName = keyof typeof Definitions
 const KeybindNames = new Set<string>(Object.keys(Definitions))
 
-export const KeybindOverrides = Schema.Struct(
-  Object.fromEntries(
-    Object.entries(Definitions).map(([name, item]) => [
-      name,
-      Schema.optional(BindingValueSchema).annotate({ description: item.description }),
+const VimModeScopes = {
+  "vim.normal": ["normal"],
+} as const satisfies Record<string, readonly string[]>
+
+type VimModeScope = keyof typeof VimModeScopes
+const VimModeScopeNames = new Set<string>(Object.keys(VimModeScopes))
+
+const KeybindOverrideFields = Object.fromEntries(
+  Object.entries(Definitions).map(([name, item]) => [
+    name,
+    Schema.optional(BindingValueSchema).annotate({ description: item.description }),
+  ]),
+)
+
+const KeybindOverrideBase = Schema.Struct(KeybindOverrideFields)
+
+export const KeybindOverrides = Schema.Struct({
+  ...KeybindOverrideFields,
+  ...Object.fromEntries(
+    Object.keys(VimModeScopes).map((scope) => [
+      scope,
+      Schema.optional(KeybindOverrideBase).annotate({ description: `TUI keybinding overrides scoped to ${scope}` }),
     ]),
   ),
-).annotate({ description: "TUI keybinding overrides" })
+}).annotate({ description: "TUI keybinding overrides" })
 export const Descriptions = Object.fromEntries(
   Object.entries(Definitions).map(([name, item]) => [name, item.description]),
 ) as Record<KeybindName, string>
@@ -435,7 +453,7 @@ const CommandDescriptions = Object.fromEntries(
 ) as Record<string, string>
 
 export type Keybinds = { [K in KeybindName]: BindingValueSchema }
-export type KeybindOverrides = Partial<Keybinds>
+export type KeybindOverrides = Partial<Keybinds> & Partial<Record<VimModeScope, Partial<Keybinds>>>
 export type BindingLookupView = {
   readonly bindings: readonly Binding<Renderable, KeyEvent>[]
   get(command: string): readonly Binding<Renderable, KeyEvent>[]
@@ -458,18 +476,73 @@ export function defaultValue(name: KeybindName) {
 export function parse(keybinds: KeybindOverrides): Keybinds {
   const invalid = unknownKeys(keybinds)
   if (invalid.length) throw new Error(`Unrecognized keybind${invalid.length === 1 ? "" : "s"}: ${invalid.join(", ")}`)
-  return Object.fromEntries(
+  const result = Object.fromEntries(
     Object.entries(Definitions).map(([name, item]) => [
       name,
       decodeBindingValue(keybinds[name as KeybindName] ?? item.default),
     ]),
   ) as Keybinds
+
+  for (const [scope, modes] of Object.entries(VimModeScopes)) {
+    const scoped = keybinds[scope as VimModeScope]
+    if (!scoped || typeof scoped !== "object" || Array.isArray(scoped)) continue
+    for (const [name, value] of Object.entries(scoped)) {
+      if (!KeybindNames.has(name)) continue
+      const scopedItems = scopedBindingItems(decodeBindingValue(value), modes)
+      if (!scopedItems.length) continue
+      result[name as KeybindName] = appendBindingItems(result[name as KeybindName], scopedItems)
+    }
+  }
+
+  return result
 }
 
 export const Keybinds = { parse }
 
 export function unknownKeys(input: object) {
-  return Object.keys(input).filter((key) => !KeybindNames.has(key))
+  return Object.entries(input).flatMap(([key, value]) => {
+    if (KeybindNames.has(key)) return []
+    if (!VimModeScopeNames.has(key)) return [key]
+    if (!value || typeof value !== "object" || Array.isArray(value)) return []
+    return Object.keys(value).filter((nested) => !KeybindNames.has(nested)).map((nested) => `${key}.${nested}`)
+  })
+}
+
+export function dropUnknown(input: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(input).flatMap(([key, value]) => {
+      if (KeybindNames.has(key)) return [[key, value]]
+      if (!VimModeScopeNames.has(key)) return []
+      if (!value || typeof value !== "object" || Array.isArray(value)) return [[key, value]]
+      const nested = Object.fromEntries(Object.entries(value).filter(([nestedKey]) => KeybindNames.has(nestedKey)))
+      return [[key, nested]]
+    }),
+  )
+}
+
+function isBindingItemArray(value: BindingValueSchema): value is readonly BindingItem[] {
+  return Array.isArray(value)
+}
+
+function bindingItems(value: BindingValueSchema): readonly BindingItem[] {
+  if (value === false || value === "none") return []
+  return isBindingItemArray(value) ? value : [value]
+}
+
+function scopedBindingItems(value: BindingValueSchema, modes: readonly string[]): BindingItem[] {
+  return bindingItems(value).flatMap((item) =>
+    modes.map((vimMode) => {
+      if (typeof item === "string" || !("key" in item)) return { key: item, vimMode }
+      return { ...item, vimMode }
+    }),
+  )
+}
+
+function appendBindingItems(value: BindingValueSchema, items: readonly BindingItem[]): BindingValueSchema {
+  if (items.length === 0) return value
+  if (value === false || value === "none") return items
+  if (isBindingItemArray(value)) return [...value, ...items]
+  return [value, ...items]
 }
 
 export function bindingDefaults(): BindingDefaults<Renderable, KeyEvent> {

--- a/packages/tui/src/keymap.tsx
+++ b/packages/tui/src/keymap.tsx
@@ -27,6 +27,7 @@ export const OPENCODE_COPY_MODE_EXIT_KEYS = `<${VIM_WINDOW_TOKEN}>j,<${VIM_WINDO
 export const COMMAND_PALETTE_COMMAND = "command.palette.show"
 
 const OPENCODE_MODE_KEY = "opencode.mode"
+export const OPENCODE_VIM_MODE_KEY = "opencode.vim.mode"
 
 export const OpencodeKeymapProvider = KeymapProvider
 export const useOpencodeKeymap = useKeymap
@@ -58,9 +59,14 @@ function isVisiblePaletteCommand(command: Command) {
 export function createOpencodeModeStack(keymap: OpenTuiKeymap) {
   keymap.setData(OPENCODE_MODE_KEY, OPENCODE_BASE_MODE)
 
-  const offFields = keymap.registerLayerFields({
+  const offLayerFields = keymap.registerLayerFields({
     mode(value, ctx) {
       ctx.require(OPENCODE_MODE_KEY, value)
+    },
+  })
+  const offBindingFields = keymap.registerBindingFields({
+    vimMode(value, ctx) {
+      ctx.require(OPENCODE_VIM_MODE_KEY, value)
     },
   })
 
@@ -94,7 +100,8 @@ export function createOpencodeModeStack(keymap: OpenTuiKeymap) {
       if (disposed) return
       disposed = true
       stack.length = 0
-      offFields()
+      offBindingFields()
+      offLayerFields()
       keymap.setData(OPENCODE_MODE_KEY, undefined)
       modeStacks.delete(keymap)
     },

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -10,6 +10,7 @@ import { useTuiConfig } from "../../config"
 import {
   OPENCODE_COPY_MODE_ENTER_KEYS,
   OPENCODE_COPY_MODE_TOGGLE_KEYS,
+  OPENCODE_VIM_MODE_KEY,
   useBindings,
   useOpencodeKeymap,
   useOpencodeModeStack,
@@ -28,6 +29,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   const keymap = useOpencodeKeymap()
   const modeStack = useOpencodeModeStack()
   const vimEnabled = useVimEnabled()
+  const previousVimMode = keymap.getData(OPENCODE_VIM_MODE_KEY)
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -58,6 +60,14 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     return store.answers[store.tab]?.includes(value) ?? false
   })
   const modalInputEnabled = createMemo(() => vimEnabled() && tuiConfig.vim_modal_input)
+
+  createEffect(() => {
+    keymap.setData(OPENCODE_VIM_MODE_KEY, modalInputEnabled() ? store.inputMode : undefined)
+  })
+
+  onCleanup(() => {
+    keymap.setData(OPENCODE_VIM_MODE_KEY, previousVimMode)
+  })
   const answerInput = createModalInputControls({
     mode: () => store.inputMode,
     setMode: (mode) => setStore("inputMode", mode),

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -19,7 +19,7 @@ import { createModalInputControls, type ModalInputKeyEvent, type ModalInputMode 
 import { Locale } from "../util/locale"
 import { getScrollAcceleration } from "../util/scroll"
 import { useTuiConfig } from "../config"
-import { formatKeyBindings, useBindings, useKeymapSelector } from "../keymap"
+import { OPENCODE_VIM_MODE_KEY, formatKeyBindings, useBindings, useKeymapSelector, useOpencodeKeymap } from "../keymap"
 import { useVimEnabled } from "../component/vim"
 
 export interface DialogSelectProps<T> {
@@ -88,7 +88,9 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const dialog = useDialog()
   const { theme } = useTheme()
   const tuiConfig = useTuiConfig()
+  const keymap = useOpencodeKeymap()
   const vimEnabled = useVimEnabled()
+  const previousVimMode = keymap.getData(OPENCODE_VIM_MODE_KEY)
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
 
   const [store, setStore] = createStore({
@@ -100,6 +102,15 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const [focusedAction, setFocusedAction] = createSignal<number>()
   const actionFocused = createMemo(() => focusedAction() !== undefined)
   const modalInputEnabled = createMemo(() => vimEnabled() && props.renderFilter !== false && (props.modalInput ?? tuiConfig.vim_modal_input))
+
+  createEffect(() => {
+    keymap.setData(OPENCODE_VIM_MODE_KEY, modalInputEnabled() ? store.inputMode : undefined)
+  })
+
+  onCleanup(() => {
+    keymap.setData(OPENCODE_VIM_MODE_KEY, previousVimMode)
+  })
+
   let selection: { value: T; category?: string } | undefined
   let resetSelection = false
   let visibilityGeneration = 0

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -12,6 +12,7 @@ import {
   type Info as TuiConfigInfo,
   useTuiConfig,
 } from "../src/config"
+import { TuiKeybind } from "../src/config/keybind"
 
 const decodeInfo = Schema.decodeUnknownSync(Info)
 const decodePlugin = Schema.decodeUnknownSync(PluginSpec)
@@ -39,6 +40,21 @@ test("validates config constraints", () => {
   expect(() => decodeInfo({ prompt: { max_width: 0 } })).toThrow()
   expect(() => decodeInfo({ scroll_speed: 0 })).toThrow()
   expect(decodeInfo({ attention: { sounds: { unknown: "sound.wav" } } })).toEqual({ attention: { sounds: {} } })
+  expect(decodeInfo({ keybinds: { "vim.normal": { input_move_down: "j" } } })).toEqual({
+    keybinds: { "vim.normal": { input_move_down: "j" } },
+  })
+  expect(() => decodeInfo({ keybinds: { "vim.normal": "j" } })).toThrow()
+})
+
+test("drops unknown keybinds without hiding invalid known scopes", () => {
+  const keybinds = TuiKeybind.dropUnknown({
+    not_a_real_keybind: "ctrl+q",
+    "vim.normal": "j",
+    "vim.unknown": { input_move_down: "j" },
+  })
+
+  expect(keybinds).toEqual({ "vim.normal": "j" })
+  expect(() => decodeInfo({ keybinds })).toThrow()
 })
 
 test("resolves host-neutral defaults", () => {
@@ -84,6 +100,46 @@ test("resolves a session move keybind", () => {
   const config = resolve({ keybinds: { session_move: "ctrl+o" } }, { terminalSuspend: true })
 
   expect(config.keybinds.get("session.move")).toMatchObject([{ key: "ctrl+o" }])
+})
+
+test("resolves vim mode-scoped keybinds", () => {
+  const config = resolve(
+    {
+      keybinds: {
+        input_move_down: "down",
+        "vim.normal": {
+          input_move_down: "j",
+          input_move_up: [{ key: "k", preventDefault: false }],
+        },
+      },
+    },
+    { terminalSuspend: true },
+  )
+
+  expect(config.keybinds.get("input.move.down")).toMatchObject([
+    { key: "down", cmd: "input.move.down" },
+    { key: "j", cmd: "input.move.down", vimMode: "normal" },
+  ])
+  expect(config.keybinds.get("input.move.up")).toMatchObject([
+    { key: "up", cmd: "input.move.up" },
+    { key: "k", cmd: "input.move.up", vimMode: "normal", preventDefault: false },
+  ])
+})
+
+test("vim mode-scoped keybinds re-enable a globally disabled command", () => {
+  const config = resolve(
+    {
+      keybinds: {
+        input_move_down: "none",
+        "vim.normal": {
+          input_move_down: "j",
+        },
+      },
+    },
+    { terminalSuspend: true },
+  )
+
+  expect(config.keybinds.get("input.move.down")).toMatchObject([{ key: "j", cmd: "input.move.down", vimMode: "normal" }])
 })
 
 test("disables suspend and assigns ctrl+z to undo when unsupported", () => {

--- a/packages/tui/test/keymap-vim.test.ts
+++ b/packages/tui/test/keymap-vim.test.ts
@@ -5,6 +5,7 @@ import {
   OPENCODE_COPY_MODE,
   OPENCODE_COPY_MODE_ENTER_KEYS,
   OPENCODE_COPY_MODE_TOGGLE_KEYS,
+  OPENCODE_VIM_MODE_KEY,
   VIM_WINDOW_TOKEN,
 } from "../src/keymap"
 
@@ -123,6 +124,28 @@ describe("opencode keymap", () => {
 
     expect(calls).toEqual(["toggle-copy"])
     expect(testKeymap.keymap.getPendingSequence()).toEqual([])
+  })
+
+  test("vim mode-scoped bindings only run in matching vim mode", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+    const offFields = testKeymap.keymap.registerBindingFields({
+      vimMode(value, ctx) {
+        ctx.require(OPENCODE_VIM_MODE_KEY, value)
+      },
+    })
+
+    testKeymap.keymap.registerLayer({
+      bindings: [{ key: "j", vimMode: "normal", cmd: () => void calls.push("normal:j") }],
+    })
+
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "insert")
+    testKeymap.host.press("j")
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "normal")
+    testKeymap.host.press("j")
+
+    expect(calls).toEqual(["normal:j"])
+    offFields()
   })
 
   test("copy mode ctrl scroll bindings can claim keys before global bindings", () => {


### PR DESCRIPTION
Part of #217 

Adds support for normal mode scoped keybinds in the TUI via `keybinds["vim.normal"]`, so commands can be bound only while in normal mode. 

Does not support `keybinds["vim.normal"].leader`.