### PR TITLE
feat(keymap): support normal mode only leader binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ Bind existing commands only in normal mode by nesting overrides under `vim.norma
 }
 ```
 
+```json
+{
+  // Use <space> as leader
+  "keybinds": {
+    "vim.normal": {
+      "leader": "space"
+    }
+  }
+}
+```
+
+When `vim.normal.leader` is set without a top-level `leader`, it replaces the implicit default global leader (`Ctrl+X`). Configure both to keep both leaders.
+
 ### Prompt input height
 
 Configure prompt input height in `tui.json`:

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -476,10 +476,15 @@ export function defaultValue(name: KeybindName) {
 export function parse(keybinds: KeybindOverrides): Keybinds {
   const invalid = unknownKeys(keybinds)
   if (invalid.length) throw new Error(`Unrecognized keybind${invalid.length === 1 ? "" : "s"}: ${invalid.join(", ")}`)
+  const scopedLeader = hasScopedKeybind(keybinds, "leader")
   const result = Object.fromEntries(
     Object.entries(Definitions).map(([name, item]) => [
       name,
-      decodeBindingValue(keybinds[name as KeybindName] ?? item.default),
+      decodeBindingValue(
+        scopedLeader && name === "leader" && keybinds.leader === undefined
+          ? "none"
+          : keybinds[name as KeybindName] ?? item.default,
+      ),
     ]),
   ) as Keybinds
 
@@ -498,6 +503,13 @@ export function parse(keybinds: KeybindOverrides): Keybinds {
 }
 
 export const Keybinds = { parse }
+
+function hasScopedKeybind(keybinds: KeybindOverrides, name: KeybindName) {
+  return Object.keys(VimModeScopes).some((scope) => {
+    const scoped = keybinds[scope as VimModeScope]
+    return !!scoped && typeof scoped === "object" && !Array.isArray(scoped) && name in scoped
+  })
+}
 
 export function unknownKeys(input: object) {
   return Object.entries(input).flatMap(([key, value]) => {

--- a/packages/tui/src/keymap.tsx
+++ b/packages/tui/src/keymap.tsx
@@ -5,9 +5,15 @@ import {
   registerCommaBindings,
   registerEscapeClearsPendingSequence,
   registerManagedTextareaLayer,
-  registerTimedLeader,
 } from "@opentui/keymap/addons/opentui"
-import { stringifyKeyStroke, type Binding } from "@opentui/keymap"
+import {
+  stringifyKeyStroke,
+  type Binding,
+  type KeyLike,
+  type Keymap,
+  type KeymapEvent,
+  type KeySequencePart,
+} from "@opentui/keymap"
 import {
   formatCommandBindings as formatCommandBindingsExtra,
   formatKeySequence as formatKeySequenceExtra,
@@ -195,8 +201,77 @@ function leaderDisplay(config: FormatConfig) {
   return typeof key === "string" ? key : stringifyKeyStroke(key)
 }
 
-function leaderKey(config: FormatConfig) {
-  return config.keybinds.get(LEADER_TOKEN)?.[0]?.key
+type LeaderBinding = Binding<Renderable, KeyEvent> & { vimMode?: unknown }
+
+const SCOPED_LEADER_TOKEN_KEY = { name: "opencode-scoped-leader" } as const
+
+export function registerOpencodeLeader<TTarget extends object, TEvent extends KeymapEvent>(
+  keymap: Keymap<TTarget, TEvent>,
+  config: FormatConfig & { leader_timeout: number },
+) {
+  const bindings = config.keybinds.get(LEADER_TOKEN) as readonly LeaderBinding[]
+  const global = bindings.find((binding) => binding.vimMode === undefined)
+  const scoped = bindings.filter((binding) => binding.vimMode === "normal")
+  if (!global && scoped.length === 0) return () => {}
+
+  const tokenKey = global?.key ?? SCOPED_LEADER_TOKEN_KEY
+  const offToken = keymap.registerToken({ name: LEADER_TOKEN, key: tokenKey })
+  const offScoped = scoped.length
+    ? registerScopedLeaderMatches(keymap, tokenKey, scoped.map((binding) => binding.key))
+    : () => {}
+  const offTimeout = registerLeaderTimeout(keymap, tokenKey, config.leader_timeout)
+
+  return () => {
+    offTimeout()
+    offScoped()
+    offToken()
+  }
+}
+
+function registerScopedLeaderMatches<TTarget extends object, TEvent extends KeymapEvent>(
+  keymap: Keymap<TTarget, TEvent>,
+  tokenKey: KeyLike,
+  triggers: readonly KeyLike[],
+) {
+  const matchers = triggers.map((trigger) => keymap.createKeyMatcher(trigger))
+  return keymap.prependEventMatchResolver((event, ctx) => {
+    if (keymap.getData(OPENCODE_VIM_MODE_KEY) !== "normal") return
+    if (!matchers.some((matches) => matches(event))) return
+    return [ctx.resolveKey(tokenKey)]
+  })
+}
+
+function registerLeaderTimeout<TTarget extends object, TEvent extends KeymapEvent>(
+  keymap: Keymap<TTarget, TEvent>,
+  tokenKey: KeyLike,
+  timeoutMs: number,
+) {
+  const matchesLeader = keymap.createKeyMatcher(tokenKey)
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  function clearTimer() {
+    if (!timeout) return
+    clearTimeout(timeout)
+    timeout = undefined
+  }
+
+  function sync(sequence: readonly KeySequencePart[]) {
+    const nextArmed = matchesLeader(sequence[0])
+    if (nextArmed) {
+      clearTimer()
+      timeout = setTimeout(() => keymap.clearPendingSequence(), timeoutMs)
+    } else {
+      clearTimer()
+    }
+  }
+
+  const offPendingSequence = keymap.on("pendingSequence", sync)
+  sync(keymap.getPendingSequence())
+
+  return () => {
+    clearTimer()
+    offPendingSequence()
+  }
 }
 
 function formatOptions(config: FormatConfig) {
@@ -228,14 +303,7 @@ export function registerOpencodeKeymap(keymap: OpenTuiKeymap, renderer: CliRende
   const offCommaBindings = registerCommaBindings(keymap)
   const offAliasExpander = registerKeyAliases(keymap)
   const offBaseLayout = registerBaseLayoutFallback(keymap)
-  const leader = leaderKey(config)
-  const offLeader = leader
-    ? registerTimedLeader(keymap, {
-        trigger: leader,
-        name: LEADER_TOKEN,
-        timeoutMs: config.leader_timeout,
-      })
-    : () => {}
+  const offLeader = registerOpencodeLeader(keymap, config)
   const offVimWindow = keymap.registerToken({ name: VIM_WINDOW_TOKEN, key: "ctrl+w" })
   const offEscape = registerEscapeClearsPendingSequence(keymap)
   const offBackspace = registerBackspacePopsPendingSequence(keymap)

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -102,6 +102,12 @@ test("resolves a session move keybind", () => {
   expect(config.keybinds.get("session.move")).toMatchObject([{ key: "ctrl+o" }])
 })
 
+test("resolves vim normal leader without default global leader", () => {
+  const config = resolve({ keybinds: { "vim.normal": { leader: "space" } } }, { terminalSuspend: true })
+
+  expect(config.keybinds.get("leader")).toMatchObject([{ key: "space", cmd: "leader", vimMode: "normal" }])
+})
+
 test("resolves vim mode-scoped keybinds", () => {
   const config = resolve(
     {

--- a/packages/tui/test/keymap-vim.test.ts
+++ b/packages/tui/test/keymap-vim.test.ts
@@ -1,16 +1,30 @@
 import { describe, expect, test } from "bun:test"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import * as addons from "@opentui/keymap/addons/opentui"
+import { createBindingLookup } from "@opentui/keymap/extras"
 import {
   OPENCODE_COPY_MODE,
   OPENCODE_COPY_MODE_ENTER_KEYS,
   OPENCODE_COPY_MODE_TOGGLE_KEYS,
   OPENCODE_VIM_MODE_KEY,
   VIM_WINDOW_TOKEN,
+  registerOpencodeLeader,
 } from "../src/keymap"
+import { TuiKeybind } from "../src/config/keybind"
 
 const MODE_KEY = "test.mode"
 const QUESTION_MODE = "question"
+
+function createResolvedKeymapConfig(input: TuiKeybind.KeybindOverrides = {}) {
+  const keybinds = TuiKeybind.parse(input)
+  return {
+    keybinds: createBindingLookup(TuiKeybind.toBindingConfig(keybinds), {
+      commandMap: TuiKeybind.CommandMap,
+      bindingDefaults: TuiKeybind.bindingDefaults(),
+    }),
+    leader_timeout: 2000,
+  }
+}
 
 function createModeStack(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
   const offFields = keymap.registerLayerFields({
@@ -124,6 +138,106 @@ describe("opencode keymap", () => {
 
     expect(calls).toEqual(["toggle-copy"])
     expect(testKeymap.keymap.getPendingSequence()).toEqual([])
+  })
+
+  test("default leader still starts leader sequences", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+    const config = createResolvedKeymapConfig({ session_new: "<leader>n" })
+    const offLeader = registerOpencodeLeader(testKeymap.keymap, config)
+
+    testKeymap.keymap.registerLayer({
+      bindings: [{ key: "<leader>n", cmd: "session.new" }],
+      commands: [{ name: "session.new", run: () => void calls.push("new") }],
+    })
+
+    testKeymap.host.press("x", { ctrl: true })
+    testKeymap.host.press("n")
+
+    expect(calls).toEqual(["new"])
+    offLeader()
+  })
+
+  test("vim normal leader only starts leader sequences in normal mode", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+    const config = createResolvedKeymapConfig({
+      "vim.normal": { leader: "space" },
+      session_new: "<leader>n",
+    })
+    const offLeader = registerOpencodeLeader(testKeymap.keymap, config)
+
+    testKeymap.keymap.registerLayer({
+      bindings: [{ key: "<leader>n", cmd: "session.new" }],
+      commands: [{ name: "session.new", run: () => void calls.push("new") }],
+    })
+
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "insert")
+    testKeymap.host.press("space")
+    testKeymap.host.press("n")
+    testKeymap.host.press("x", { ctrl: true })
+    testKeymap.host.press("n")
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "normal")
+    testKeymap.host.press("space")
+    testKeymap.host.press("n")
+
+    expect(calls).toEqual(["new"])
+    offLeader()
+  })
+
+  test("vim normal leader takes priority over exact leader-key bindings", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+    const config = createResolvedKeymapConfig({
+      "vim.normal": { leader: "space" },
+      session_new: "<leader>n",
+    })
+    const offLeader = registerOpencodeLeader(testKeymap.keymap, config)
+
+    testKeymap.keymap.registerLayer({
+      bindings: [
+        { key: "space", cmd: () => void calls.push("space") },
+        { key: "<leader>n", cmd: "session.new" },
+      ],
+      commands: [{ name: "session.new", run: () => void calls.push("new") }],
+    })
+
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "insert")
+    testKeymap.host.press("space")
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "normal")
+    testKeymap.host.press("space")
+    testKeymap.host.press("n")
+
+    expect(calls).toEqual(["space", "new"])
+    offLeader()
+  })
+
+  test("explicit global leader still works with vim normal leader", () => {
+    const testKeymap = createTestKeymap({ defaultKeys: true })
+    const calls: string[] = []
+    const config = createResolvedKeymapConfig({
+      leader: "ctrl+x",
+      "vim.normal": { leader: "space" },
+      session_new: "<leader>n",
+    })
+    const offLeader = registerOpencodeLeader(testKeymap.keymap, config)
+
+    testKeymap.keymap.registerLayer({
+      bindings: [{ key: "<leader>n", cmd: "session.new" }],
+      commands: [{ name: "session.new", run: () => void calls.push("new") }],
+    })
+
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "insert")
+    testKeymap.host.press("x", { ctrl: true })
+    testKeymap.host.press("n")
+    testKeymap.host.press("space")
+    testKeymap.host.press("n")
+    testKeymap.keymap.setData(OPENCODE_VIM_MODE_KEY, "normal")
+    testKeymap.host.press("space")
+    testKeymap.host.press("n")
+
+    expect(calls).toEqual(["new", "new"])
+    offLeader()
   })
 
   test("vim mode-scoped bindings only run in matching vim mode", () => {


### PR DESCRIPTION
Closes #217

Adds support for configuring a normal mode only leader key via `keybinds["vim.normal"].leader`:

 ```json
   {
     "keybinds": {
       "vim.normal": {
         "leader": "space"
       }
     }
   }
 ```