### PR TITLE
feat(prompt): add display line motions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Toggle via command palette > `Toggle minimal ui`.
 | `vim_system_clipboard_register` | Use the system clipboard as Vim register |
 | `vim_modal_input`               | Enable Vim controls in dialogs           |
 | `vim_langmap`                   | Map non-English keys or simple aliases   |
+| `vim_line_motions`              | Use wrapped display-line motions         |
 | `vim_escape_sequence`           | Use a two-key escape sequence like `jk`  |
 
 ### Mode-scoped keybinds
@@ -277,6 +278,24 @@ Or or for simple aliases:
   }
 }
 ```
+
+### Vim line motions
+
+Choose how motions handle wrapped lines in the prompt:
+
+```json
+{
+  "vim_line_motions": "logical"
+}
+```
+
+Values:
+
+| Value              | Behavior                                                    |
+| ------------------ | ----------------------------------------------------------- |
+| `logical`          | Vertical and boundary motions use logical lines             |
+| `display_vertical` | Vertical motions use display lines; boundaries stay logical |
+| `display`          | Vertical and boundary motions use display lines             |
 
 ### Vim escape sequence
 

--- a/packages/opencode/src/config/tui-migrate.ts
+++ b/packages/opencode/src/config/tui-migrate.ts
@@ -13,6 +13,7 @@ const TUI_SCHEMA_URL = "https://opencode.ai/tui.json"
 const decodeTheme = Schema.decodeUnknownOption(Schema.String)
 const decodeRecord = Schema.decodeUnknownOption(Schema.Record(Schema.String, Schema.Unknown))
 const decodeLangmap = Schema.decodeUnknownOption(TuiConfig.VimLangmap)
+const decodeLineMotions = Schema.decodeUnknownOption(TuiConfig.VimLineMotions)
 const decodeScrollSpeed = Schema.decodeUnknownOption(TuiConfig.ScrollSpeed)
 const decodeScrollAcceleration = Schema.decodeUnknownOption(TuiConfig.ScrollAcceleration)
 const decodeDiffStyle = Schema.decodeUnknownOption(TuiConfig.DiffStyle)
@@ -79,6 +80,7 @@ function normalizeTui(data: Record<string, unknown>):
       vim_system_clipboard_register: boolean | undefined
       vim_modal_input: boolean | undefined
       vim_langmap: Record<string, string> | undefined
+      vim_line_motions: "logical" | "display_vertical" | "display" | undefined
     }
   | undefined {
   const parsed = {
@@ -90,6 +92,7 @@ function normalizeTui(data: Record<string, unknown>):
     vim_system_clipboard_register: Option.getOrUndefined(decodeBoolean(data.vim_system_clipboard_register)),
     vim_modal_input: Option.getOrUndefined(decodeBoolean(data.vim_modal_input)),
     vim_langmap: Option.getOrUndefined(decodeLangmap(data.vim_langmap)),
+    vim_line_motions: Option.getOrUndefined(decodeLineMotions(data.vim_line_motions)),
   }
   return parsed.scroll_speed === undefined &&
     parsed.diff_style === undefined &&
@@ -98,7 +101,8 @@ function normalizeTui(data: Record<string, unknown>):
     parsed.vim_insert_after_submit === undefined &&
     parsed.vim_system_clipboard_register === undefined &&
     parsed.vim_modal_input === undefined &&
-    parsed.vim_langmap === undefined
+    parsed.vim_langmap === undefined &&
+    parsed.vim_line_motions === undefined
     ? undefined
     : parsed
 }

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -218,6 +218,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
           vim_insert_after_submit: true,
           vim_modal_input: false,
           vim_langmap: { д: "l" },
+          vim_line_motions: "display",
         },
         keybinds: { app_exit: "ctrl+q" },
       })
@@ -229,6 +230,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       expect(config.vim_insert_after_submit).toBe(true)
       expect(config.vim_modal_input).toBe(false)
       expect(config.vim_langmap).toEqual({ д: "l" })
+      expect(config.vim_line_motions).toBe("display")
       expect(config.keybinds.get("app.exit")?.[0]?.key).toBe("ctrl+q")
       expect(JSON.parse(yield* fs.readFileString(path.join(test.directory, "tui.json")))).toMatchObject({
         theme: "migrated-theme",
@@ -237,6 +239,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
         vim_insert_after_submit: true,
         vim_modal_input: false,
         vim_langmap: { д: "l" },
+        vim_line_motions: "display",
       })
       const server = JSON.parse(yield* fs.readFileString(source))
       expect(server.theme).toBeUndefined()
@@ -255,6 +258,17 @@ it.instance("validates vim langmap entries are single characters", () =>
     expect(Option.isSome(decode({ vim_langmap: { д: "l" } }))).toBe(true)
     expect(Option.isNone(decode({ vim_langmap: { дд: "l" } }))).toBe(true)
     expect(Option.isNone(decode({ vim_langmap: { д: "ll" } }))).toBe(true)
+  }),
+)
+
+it.instance("validates vim line motion modes", () =>
+  Effect.sync(() => {
+    const decode = Schema.decodeUnknownOption(TuiConfig.Info)
+
+    expect(Option.isSome(decode({ vim_line_motions: "logical" }))).toBe(true)
+    expect(Option.isSome(decode({ vim_line_motions: "display_vertical" }))).toBe(true)
+    expect(Option.isSome(decode({ vim_line_motions: "display" }))).toBe(true)
+    expect(Option.isNone(decode({ vim_line_motions: "wrapped" }))).toBe(true)
   }),
 )
 

--- a/packages/tui/src/component/prompt/vim.ts
+++ b/packages/tui/src/component/prompt/vim.ts
@@ -249,6 +249,7 @@ export function usePromptVim(opts: {
       return !flashSpan || sel.start !== flashSpan.start || sel.end !== flashSpan.end
     },
     langmap: () => cfg.vim_langmap,
+    vimLineMotions: () => cfg.vim_line_motions,
     vimEscapeSequence: cfg.vim_escape_sequence,
     submit: opts.submit,
     commandPalette() {

--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -96,6 +96,7 @@ type VimSearchDirection = "forward" | "backward"
 type VimTextObjectScope = "inner" | "around"
 
 type VimKeyLike = { name?: string; shift?: boolean; sequence?: string; raw?: string }
+type VimLineMotions = "logical" | "display_vertical" | "display"
 
 export function vimLangmapKeyName(event: VimKeyLike) {
   return vimEventText(event) ?? normalizedKeyName(event)
@@ -196,10 +197,11 @@ export function createVimHandler(input: {
   setRegister?: (register: VimRegister, notify?: boolean) => void
   pasteOverSelection?: () => boolean
   langmap?: Accessor<Record<string, string> | undefined>
+  vimLineMotions?: Accessor<VimLineMotions | undefined>
   vimEscapeSequence?: string
 }) {
   let wantedColumn: VimWantedColumn | undefined
-  let visualWantedColumn: number | undefined
+  let visualWantedColumn: VimWantedColumn | undefined
   let pendingOperatorCount = 1
   let pendingOperatorFind: { operation: VimOperator; find: VimFindOperator } | undefined
   let pendingOperatorDisplay: VimOperator | undefined
@@ -222,6 +224,19 @@ export function createVimHandler(input: {
 
   function hasModifier(event: VimEvent) {
     return !!event.ctrl || !!event.meta || !!event.super
+  }
+
+  function lineMotions() {
+    return input.vimLineMotions?.() ?? "logical"
+  }
+
+  function displayVerticalLineMotions() {
+    const mode = lineMotions()
+    return mode === "display_vertical" || mode === "display"
+  }
+
+  function displayLineBoundaryMotions() {
+    return lineMotions() === "display"
   }
 
   function isPrintable(event: VimEvent) {
@@ -338,6 +353,7 @@ export function createVimHandler(input: {
   }
 
   function preservesWantedColumn(event: VimEvent, key: string) {
+    if (key === "g" && !event.shift && !hasModifier(event)) return true
     if ((key === "j" || key === "k" || key === "down" || key === "up") && !event.shift && !hasModifier(event))
       return true
     return (key === "v" || isShifted(event, "v")) && !hasModifier(event)
@@ -345,6 +361,13 @@ export function createVimHandler(input: {
 
   function preservesVisualWantedColumn(event: VimEvent, key: string) {
     if (key === "g" && !event.shift && !hasModifier(event)) return true
+    if (
+      displayVerticalLineMotions() &&
+      (key === "j" || key === "k" || key === "down" || key === "up") &&
+      !event.shift &&
+      !hasModifier(event)
+    )
+      return true
     return (
       input.state.pending() === "g" &&
       (key === "j" || key === "k" || key === "down" || key === "up") &&
@@ -545,12 +568,19 @@ export function createVimHandler(input: {
     return substituteLine(textarea, anchor)
   }
 
-  function moveDisplayVertical(direction: "up" | "down", count: number, column: number | undefined) {
+  function prepareDisplayWantedColumn() {
+    const view = input.textarea().editorView as { getVisualCursor?: () => { visualCol: number } }
+    visualWantedColumn ??= wantedColumn === "end" ? "end" : view.getVisualCursor?.().visualCol
+    clearWantedColumn()
+  }
+
+  function moveDisplayVertical(direction: "up" | "down", count: number, column: VimWantedColumn | undefined) {
     repeatCount(count, () => {
       direction === "down" ? moveVisualLineDown(input.textarea()) : moveVisualLineUp(input.textarea())
       // Native visual moves can land on trailing newlines.
       clampCursorToLine(input.textarea())
-      if (column !== undefined) alignVisualColumn(input.textarea(), column)
+      if (column === "end") moveVisualLineEnd(input.textarea())
+      else if (column !== undefined) alignVisualColumn(input.textarea(), column)
     })
   }
 
@@ -696,6 +726,7 @@ export function createVimHandler(input: {
   function verticalMotionOperator(event: VimEvent, key: string, operation: VimOperator): boolean {
     const direction = key === "j" || key === "down" ? "down" : key === "k" || key === "up" ? "up" : undefined
     if (!direction || event.shift || hasModifier(event)) return false
+    if (displayVerticalLineMotions()) return visualLineMotionOperator(key, operation)
 
     const count = takeOperatorCount()
     if (operation === "y") {
@@ -767,6 +798,11 @@ export function createVimHandler(input: {
   }
 
   function lineBoundaryMotion(event: VimEvent, key: string, operation: VimOperator): boolean {
+    if (displayLineBoundaryMotions()) {
+      if (key === "$" && !hasModifier(event)) return visualLineHorizontalMotionOperator(key, operation)
+      if (key === "0" && !event.shift && !hasModifier(event)) return visualLineHorizontalMotionOperator(key, operation)
+      if (key === "^" && !hasModifier(event)) return visualLineHorizontalMotionOperator(key, operation)
+    }
     if (key === "$" && !hasModifier(event)) {
       const count = takeOperatorCount()
       applyOperatorResult(() => lineEndCountOperation(count), operation)
@@ -1035,10 +1071,8 @@ export function createVimHandler(input: {
         } else {
           const direction = key === "j" || key === "down" ? "down" : "up"
           const count = takeCount()
-          const view = input.textarea().editorView as { getVisualCursor?: () => { visualCol: number } }
-          visualWantedColumn ??= view.getVisualCursor?.().visualCol
+          prepareDisplayWantedColumn()
           input.state.clearPending()
-          clearWantedColumn()
           moveDisplayVertical(direction, count, visualWantedColumn)
         }
         event.preventDefault()
@@ -1053,6 +1087,7 @@ export function createVimHandler(input: {
           input.state.clearPending()
           clearWantedColumn()
           moveDisplayHorizontal(key, count)
+          if (key === "$") visualWantedColumn = "end"
         }
         event.preventDefault()
         return true
@@ -1065,6 +1100,7 @@ export function createVimHandler(input: {
     if (jump.handled) {
       if (jump.action) {
         input.state.clearPending()
+        clearWantedColumn()
         clearVisualWantedColumn()
         input.jump(jump.action)
       }
@@ -1584,7 +1620,13 @@ export function createVimHandler(input: {
     }
 
     if ((key === "j" || key === "down") && !event.shift && !hasModifier(event)) {
-      countedMotion(() => moveVertical("down"))
+      if (displayVerticalLineMotions()) {
+        const count = takeCount()
+        prepareDisplayWantedColumn()
+        moveDisplayVertical("down", count, visualWantedColumn)
+      } else {
+        countedMotion(() => moveVertical("down"))
+      }
       event.preventDefault()
       return true
     }
@@ -1608,27 +1650,40 @@ export function createVimHandler(input: {
     }
 
     if ((key === "k" || key === "up") && !event.shift && !hasModifier(event)) {
-      countedMotion(() => moveVertical("up"))
+      if (displayVerticalLineMotions()) {
+        const count = takeCount()
+        prepareDisplayWantedColumn()
+        moveDisplayVertical("up", count, visualWantedColumn)
+      } else {
+        countedMotion(() => moveVertical("up"))
+      }
       event.preventDefault()
       return true
     }
 
     if (key === "0" && !event.shift && !hasModifier(event)) {
-      moveLineBeginning(input.textarea())
+      if (displayLineBoundaryMotions()) moveDisplayHorizontal("0", 1)
+      else moveLineBeginning(input.textarea())
       event.preventDefault()
       return true
     }
 
     if ((key === "^" || key === "_") && !hasModifier(event)) {
-      moveFirstNonWhitespace(input.textarea())
+      if (displayLineBoundaryMotions() && key === "^") moveDisplayHorizontal("^", 1)
+      else moveFirstNonWhitespace(input.textarea())
       event.preventDefault()
       return true
     }
 
     if (key === "$" && !hasModifier(event)) {
-      repeatCount(takeCount() - 1, () => moveLineDown(input.textarea(), 0))
-      moveLineEnd(input.textarea())
-      wantedColumn = "end"
+      if (displayLineBoundaryMotions()) {
+        moveDisplayHorizontal("$", takeCount())
+        visualWantedColumn = "end"
+      } else {
+        repeatCount(takeCount() - 1, () => moveLineDown(input.textarea(), 0))
+        moveLineEnd(input.textarea())
+        wantedColumn = "end"
+      }
       event.preventDefault()
       return true
     }

--- a/packages/tui/src/component/vim/vim-motions.ts
+++ b/packages/tui/src/component/vim/vim-motions.ts
@@ -228,20 +228,18 @@ export function moveLineDown(textarea: TextareaRenderable, column?: VimWantedCol
   textarea.cursorOffset = moveDown(text, textarea.cursorOffset, column)
 }
 
-// Display-line motions delegate wrap handling to the editor view.
+// Use TextareaRenderable's public APIs so wrapping matches OpenTUI.
 export function moveVisualLineUp(textarea: TextareaRenderable) {
-  const view = textarea.editorView as { moveUpVisual?: () => void }
-  if (typeof view?.moveUpVisual === "function") {
-    view.moveUpVisual()
+  if (typeof textarea.moveCursorUp === "function") {
+    textarea.moveCursorUp()
     return
   }
   moveLineUp(textarea)
 }
 
 export function moveVisualLineDown(textarea: TextareaRenderable) {
-  const view = textarea.editorView as { moveDownVisual?: () => void }
-  if (typeof view?.moveDownVisual === "function") {
-    view.moveDownVisual()
+  if (typeof textarea.moveCursorDown === "function") {
+    textarea.moveCursorDown()
     return
   }
   moveLineDown(textarea)
@@ -258,10 +256,7 @@ function visualRow(textarea: TextareaRenderable) {
   return typeof view?.getVisualCursor === "function" ? view.getVisualCursor().visualRow : undefined
 }
 
-export function visualLineStart(textarea: TextareaRenderable) {
-  const row = visualRow(textarea)
-  if (row === undefined) return lineStart(textarea.plainText, textarea.cursorOffset)
-
+function visualLineStartFallback(textarea: TextareaRenderable, row: number) {
   let offset = textarea.cursorOffset
   while (offset > lineStart(textarea.plainText, offset)) {
     setVisualOffset(textarea, offset - 1)
@@ -276,10 +271,7 @@ export function visualLineStart(textarea: TextareaRenderable) {
   return offset
 }
 
-export function visualLineEnd(textarea: TextareaRenderable) {
-  const row = visualRow(textarea)
-  if (row === undefined) return lineLast(textarea.plainText, textarea.cursorOffset)
-
+function visualLineEndFallback(textarea: TextareaRenderable, row: number) {
   let offset = textarea.cursorOffset
   while (offset < lineLast(textarea.plainText, offset)) {
     setVisualOffset(textarea, offset + 1)
@@ -294,7 +286,36 @@ export function visualLineEnd(textarea: TextareaRenderable) {
   return offset
 }
 
+export function visualLineStart(textarea: TextareaRenderable) {
+  const cursor = textarea.cursorOffset
+  const row = visualRow(textarea)
+  if (row === undefined) return lineStart(textarea.plainText, cursor)
+  if (typeof textarea.gotoVisualLineHome !== "function") return visualLineStartFallback(textarea, row)
+  textarea.gotoVisualLineHome()
+  const start = textarea.cursorOffset
+  setVisualOffset(textarea, cursor)
+  return start
+}
+
+export function visualLineEnd(textarea: TextareaRenderable) {
+  const cursor = textarea.cursorOffset
+  const row = visualRow(textarea)
+  if (row === undefined) return lineLast(textarea.plainText, cursor)
+  if (typeof textarea.gotoVisualLineEnd !== "function") return visualLineEndFallback(textarea, row)
+  const start = visualLineStart(textarea)
+  textarea.gotoVisualLineEnd()
+  const raw = textarea.cursorOffset
+  const exclusive = raw >= textarea.plainText.length || textarea.plainText[raw] === "\n"
+  const end = Math.max(start, exclusive ? raw - 1 : raw)
+  setVisualOffset(textarea, cursor)
+  return end
+}
+
 export function moveVisualLineBeginning(textarea: TextareaRenderable) {
+  if (typeof textarea.gotoVisualLineHome === "function") {
+    textarea.gotoVisualLineHome()
+    return
+  }
   setVisualOffset(textarea, visualLineStart(textarea))
 }
 
@@ -451,10 +472,7 @@ export function nextParagraphOperation(textarea: TextareaRenderable, operation: 
 
 // vim `{` operator. linewise for all of y/d/c when cursor is line-aligned.
 // c strips the trailing \n at cursor-1; d/y keep it.
-export function previousParagraphOperation(
-  textarea: TextareaRenderable,
-  operation: VimOperator,
-): VimOperatorResult {
+export function previousParagraphOperation(textarea: TextareaRenderable, operation: VimOperator): VimOperatorResult {
   const text = textarea.plainText
   const cursor = textarea.cursorOffset
   if (text.length === 0 || cursor === 0) return { span: null, register: null }
@@ -614,7 +632,8 @@ export function bracketTextObjectOperation(
 function bracketTextObjectInnerSpan(text: string, pair: VimSpan, operation: VimOperator) {
   const start = pair.start + 1
   const end = pair.end
-  if (text[start] === "\n" && text[end - 1] === "\n") return { start: start + 1, end: operation === "c" ? end - 1 : end }
+  if (text[start] === "\n" && text[end - 1] === "\n")
+    return { start: start + 1, end: operation === "c" ? end - 1 : end }
   return { start, end }
 }
 
@@ -678,7 +697,11 @@ function bracketTextObjectClose(text: string, start: number, end: number, open: 
   return null
 }
 
-export function quoteTextObjectOperation(textarea: TextareaRenderable, around: boolean, quote: string): VimOperatorResult {
+export function quoteTextObjectOperation(
+  textarea: TextareaRenderable,
+  around: boolean,
+  quote: string,
+): VimOperatorResult {
   const text = textarea.plainText
   if (!text.length) return { span: null, register: null }
 

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -39,6 +39,11 @@ export const VimLangmap = Schema.Record(VimLangmapCharacter, VimLangmapCharacter
   description: "Map keyboard-layout characters to Vim command keys in normal, visual, and copy modes",
 })
 
+export const VimLineMotions = Schema.Literals(["logical", "display_vertical", "display"]).annotate({
+  description: "Use logical lines, display lines for j/k only, or display lines for j/k and 0/^/$ Vim motions",
+})
+export type VimLineMotions = Schema.Schema.Type<typeof VimLineMotions>
+
 const PromptMaxHeight = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1), Schema.isLessThanOrEqualTo(50)).annotate({
   description: "Maximum number of rows the prompt input expands to",
 })
@@ -90,6 +95,7 @@ export const Info = Schema.Struct({
     description: "Use the system clipboard instead of Vim's internal register for yank and paste",
   }),
   vim_langmap: Schema.optional(VimLangmap),
+  vim_line_motions: Schema.optional(VimLineMotions),
   vim_escape_sequence: Schema.optional(Schema.String.check(Schema.isPattern(/^.{2}$/u))).annotate({
     description: "Two-character sequence to exit vim insert mode (e.g., 'jk')",
   }),
@@ -145,6 +151,7 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
     leader_timeout: input.leader_timeout ?? LeaderTimeoutDefault,
     mouse: input.mouse ?? true,
     vim_modal_input: input.vim_modal_input ?? true,
+    vim_line_motions: input.vim_line_motions ?? "logical",
   }
 }
 

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -174,6 +174,7 @@ function createHandler(
     data?: unknown
     snapshotDataEqual?: (before: unknown, after: unknown) => boolean
     langmap?: Record<string, string>
+    vimLineMotions?: "logical" | "display_vertical" | "display"
     copySearchAvailable?: boolean
     vimEscapeSequence?: string
   },
@@ -382,6 +383,7 @@ function createHandler(
     setRegister: options?.register?.set,
     pasteOverSelection: options?.pasteOverSelection,
     langmap: () => options?.langmap,
+    vimLineMotions: () => options?.vimLineMotions,
     vimEscapeSequence: options?.vimEscapeSequence,
     submit: options?.submit ?? (() => {}),
     commandPalette() {

--- a/packages/tui/test/vim-visual-line-motions.test.ts
+++ b/packages/tui/test/vim-visual-line-motions.test.ts
@@ -34,7 +34,10 @@ async function createWrappedTextarea(text: string) {
   }
 }
 
-async function createWrappedHandler(text: string) {
+async function createWrappedHandler(
+  text: string,
+  options: { vimLineMotions?: "logical" | "display_vertical" | "display" } = {},
+) {
   const setup = await createWrappedTextarea(text)
   let disposeRoot!: () => void
   const state = createRoot((dispose) => {
@@ -48,6 +51,7 @@ async function createWrappedHandler(text: string) {
     submit() {},
     scroll() {},
     jump() {},
+    vimLineMotions: () => options.vimLineMotions,
   })
   return {
     textarea: setup.textarea,
@@ -140,6 +144,126 @@ describe("visual line motions (gj/gk)", () => {
     ctx.handler.handleKey(createEvent("g"))
     ctx.handler.handleKey(createEvent("j"))
     expect(ctx.textarea.editorView.getVisualCursor().visualCol).toBe(10)
+  })
+
+  test("vim_line_motions display_vertical maps j and k to display rows", async () => {
+    using ctx = await createWrappedHandler(WRAPPED, { vimLineMotions: "display_vertical" })
+
+    ctx.handler.handleKey(createEvent("j"))
+    expect(ctx.textarea.editorView.getVisualCursor().visualRow).toBe(1)
+    expect(ctx.textarea.editorView.getVisualCursor().logicalRow).toBe(0)
+
+    ctx.handler.handleKey(createEvent("k"))
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("vim_line_motions display_vertical applies to vertical operators", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC", {
+      vimLineMotions: "display_vertical",
+    })
+
+    ctx.handler.handleKey(createEvent("d"))
+    ctx.handler.handleKey(createEvent("j"))
+
+    expect(ctx.textarea.plainText).toBe("BBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.register()).toEqual({ text: "AAAAAAAAAAAAAAAAAAAA", linewise: false })
+  })
+
+  test("vim_line_motions display_vertical keeps line boundaries logical", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC", {
+      vimLineMotions: "display_vertical",
+    })
+    ctx.textarea.cursorOffset = 24
+
+    ctx.handler.handleKey(createEvent("0"))
+    expect(ctx.textarea.cursorOffset).toBe(0)
+
+    ctx.textarea.cursorOffset = 24
+    ctx.handler.handleKey(createEvent("$"))
+    expect(ctx.textarea.cursorOffset).toBe(59)
+  })
+
+  test("vim_line_motions display_vertical transfers $ stickiness to j and k", async () => {
+    using down = await createWrappedHandler(`short\n${"A".repeat(30)}`, { vimLineMotions: "display_vertical" })
+    down.handler.handleKey(createEvent("$"))
+    down.handler.handleKey(createEvent("j"))
+    expect(down.textarea.cursorOffset).toBe(25)
+
+    using up = await createWrappedHandler(`short\n${"A".repeat(30)}`, { vimLineMotions: "display_vertical" })
+    up.textarea.cursorOffset = 30
+    up.handler.handleKey(createEvent("$"))
+    up.handler.handleKey(createEvent("k"))
+    expect(up.textarea.cursorOffset).toBe(25)
+  })
+
+  test("vim_line_motions display_vertical preserves $ stickiness through gj and gk", async () => {
+    using down = await createWrappedHandler(`short\n${"A".repeat(30)}`, { vimLineMotions: "display_vertical" })
+    down.handler.handleKey(createEvent("$"))
+    down.handler.handleKey(createEvent("g"))
+    down.handler.handleKey(createEvent("j"))
+    expect(down.textarea.cursorOffset).toBe(25)
+
+    using up = await createWrappedHandler(`short\n${"A".repeat(30)}`, { vimLineMotions: "display_vertical" })
+    up.textarea.cursorOffset = 30
+    up.handler.handleKey(createEvent("$"))
+    up.handler.handleKey(createEvent("g"))
+    up.handler.handleKey(createEvent("k"))
+    expect(up.textarea.cursorOffset).toBe(25)
+  })
+
+  test("vim_line_motions display maps line boundaries to display rows", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC", {
+      vimLineMotions: "display",
+    })
+    ctx.textarea.cursorOffset = 24
+
+    ctx.handler.handleKey(createEvent("0"))
+    expect(ctx.textarea.cursorOffset).toBe(20)
+
+    ctx.textarea.cursorOffset = 24
+    ctx.handler.handleKey(createEvent("$"))
+    expect(ctx.textarea.cursorOffset).toBe(39)
+  })
+
+  test("vim_line_motions display keeps $ sticky across display rows", async () => {
+    using ctx = await createWrappedHandler(`short\n${"A".repeat(30)}`, { vimLineMotions: "display" })
+
+    ctx.handler.handleKey(createEvent("$"))
+    expect(ctx.textarea.cursorOffset).toBe(4)
+
+    ctx.handler.handleKey(createEvent("j"))
+    expect(ctx.textarea.cursorOffset).toBe(25)
+
+    ctx.handler.handleKey(createEvent("j"))
+    expect(ctx.textarea.cursorOffset).toBe(35)
+
+    ctx.handler.handleKey(createEvent("k"))
+    expect(ctx.textarea.cursorOffset).toBe(25)
+  })
+
+  test("g$ keeps display-row end sticky for gj", async () => {
+    using ctx = await createWrappedHandler(`short\n${"A".repeat(30)}`)
+
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("$"))
+    expect(ctx.textarea.cursorOffset).toBe(4)
+
+    ctx.handler.handleKey(createEvent("g"))
+    ctx.handler.handleKey(createEvent("j"))
+    expect(ctx.textarea.cursorOffset).toBe(25)
+  })
+
+  test("vim_line_motions display maps line-boundary operators to display rows", async () => {
+    using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBB", { vimLineMotions: "display" })
+    ctx.textarea.cursorOffset = 24
+
+    ctx.handler.handleKey(createEvent("d"))
+    ctx.handler.handleKey(createEvent("0"))
+
+    expect(ctx.textarea.plainText).toBe("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBB")
+    expect(ctx.textarea.cursorOffset).toBe(20)
+    expect(ctx.state.register()).toEqual({ text: "BBBB", linewise: false })
   })
 
   test("dgj deletes one wrapped display row charwise", async () => {


### PR DESCRIPTION
Adds configurable line motions for wrapped prompt text via `vim_line_motions`, supporting logical lines, display rows for vertical movement, or display rows for both vertical and boundary motions.

Closes #235 
