### PR TITLE
fix(prompt): motion counts in visual mode

### DIFF
--- a/packages/tui/src/component/vim/vim-handler.ts
+++ b/packages/tui/src/component/vim/vim-handler.ts
@@ -315,11 +315,7 @@ export function createVimHandler(input: {
   }
 
   function isCountInput(event: VimEvent, key: string) {
-    return (
-      !input.state.pending() &&
-      !input.state.isVisual() &&
-      (isCountDigit(event, key) || (key === "0" && input.state.count()))
-    )
+    return !input.state.pending() && (isCountDigit(event, key) || (key === "0" && input.state.count()))
   }
 
   function isPendingOperatorCountInput(event: VimEvent, key: string) {

--- a/packages/tui/test/cli/tui/vim-motions.test.ts
+++ b/packages/tui/test/cli/tui/vim-motions.test.ts
@@ -6427,6 +6427,33 @@ describe("vim motion handler", () => {
     expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 7 })
   })
 
+  test("visual character motions support counts", () => {
+    const text = "one\ntwo\nthree\nfour"
+    const ctx = createHandler(text)
+
+    ctx.handler.handleKey(createEvent("v").event)
+    ctx.handler.handleKey(createEvent("2").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 2, 0))
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({
+      start: 0,
+      end: rowColToOffset(text, 2, 0) + 1,
+    })
+  })
+
+  test("visual line motions support counts", () => {
+    const text = "one\ntwo\nthree\nfour"
+    const ctx = createHandler(text)
+
+    ctx.handler.handleKey(createEvent("V").event)
+    ctx.handler.handleKey(createEvent("2").event)
+    ctx.handler.handleKey(createEvent("j").event)
+
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 2, 0))
+    expect((ctx.textarea as any).editorView.getSelection()).toEqual({ start: 0, end: 14 })
+  })
+
   test("visual j preserves desired column across short lines", () => {
     const text = "abcdef\nx\nabcdef"
     const ctx = createHandler(text)

--- a/packages/tui/test/vim-visual-line-motions.test.ts
+++ b/packages/tui/test/vim-visual-line-motions.test.ts
@@ -157,6 +157,18 @@ describe("visual line motions (gj/gk)", () => {
     expect(ctx.textarea.cursorOffset).toBe(0)
   })
 
+  test("vim_line_motions display supports counts in visual mode", async () => {
+    using ctx = await createWrappedHandler("A".repeat(100), { vimLineMotions: "display" })
+
+    ctx.handler.handleKey(createEvent("v"))
+    ctx.handler.handleKey(createEvent("3"))
+    ctx.handler.handleKey(createEvent("j"))
+
+    expect(ctx.textarea.editorView.getVisualCursor().visualRow).toBe(3)
+    expect(ctx.textarea.cursorOffset).toBe(60)
+    expect(ctx.state.count()).toBe("")
+  })
+
   test("vim_line_motions display_vertical applies to vertical operators", async () => {
     using ctx = await createWrappedHandler("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC", {
       vimLineMotions: "display_vertical",


### PR DESCRIPTION
Fix motion counts in visual mode, including wrapped display-line motions.

