### PR TITLE
feat(prompt): add wrapped line markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Toggle via command palette > `Toggle minimal ui`.
 | `vim_modal_input`               | Enable Vim controls in dialogs           |
 | `vim_langmap`                   | Map non-English keys or simple aliases   |
 | `vim_line_motions`              | Use wrapped display-line motions         |
+| `vim_showbreak`                 | Mark wrapped prompt rows                 |
 | `vim_escape_sequence`           | Use a two-key escape sequence like `jk`  |
 
 ### Mode-scoped keybinds
@@ -296,6 +297,18 @@ Values:
 | `logical`          | Vertical and boundary motions use logical lines             |
 | `display_vertical` | Vertical motions use display lines; boundaries stay logical |
 | `display`          | Vertical and boundary motions use display lines             |
+
+### Vim showbreak
+
+Set a marker for wrapped rows in the prompt:
+
+```json
+{
+  "vim_showbreak": true
+}
+```
+
+Shows `↪ ` marker in the prompt's left padding.
 
 ### Vim escape sequence
 

--- a/packages/opencode/src/config/tui-migrate.ts
+++ b/packages/opencode/src/config/tui-migrate.ts
@@ -81,6 +81,7 @@ function normalizeTui(data: Record<string, unknown>):
       vim_modal_input: boolean | undefined
       vim_langmap: Record<string, string> | undefined
       vim_line_motions: "logical" | "display_vertical" | "display" | undefined
+      vim_showbreak: boolean | undefined
     }
   | undefined {
   const parsed = {
@@ -93,6 +94,7 @@ function normalizeTui(data: Record<string, unknown>):
     vim_modal_input: Option.getOrUndefined(decodeBoolean(data.vim_modal_input)),
     vim_langmap: Option.getOrUndefined(decodeLangmap(data.vim_langmap)),
     vim_line_motions: Option.getOrUndefined(decodeLineMotions(data.vim_line_motions)),
+    vim_showbreak: Option.getOrUndefined(decodeBoolean(data.vim_showbreak)),
   }
   return parsed.scroll_speed === undefined &&
     parsed.diff_style === undefined &&
@@ -102,7 +104,8 @@ function normalizeTui(data: Record<string, unknown>):
     parsed.vim_system_clipboard_register === undefined &&
     parsed.vim_modal_input === undefined &&
     parsed.vim_langmap === undefined &&
-    parsed.vim_line_motions === undefined
+    parsed.vim_line_motions === undefined &&
+    parsed.vim_showbreak === undefined
     ? undefined
     : parsed
 }

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -219,6 +219,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
           vim_modal_input: false,
           vim_langmap: { д: "l" },
           vim_line_motions: "display",
+          vim_showbreak: true,
         },
         keybinds: { app_exit: "ctrl+q" },
       })
@@ -231,6 +232,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       expect(config.vim_modal_input).toBe(false)
       expect(config.vim_langmap).toEqual({ д: "l" })
       expect(config.vim_line_motions).toBe("display")
+      expect(config.vim_showbreak).toBe(true)
       expect(config.keybinds.get("app.exit")?.[0]?.key).toBe("ctrl+q")
       expect(JSON.parse(yield* fs.readFileString(path.join(test.directory, "tui.json")))).toMatchObject({
         theme: "migrated-theme",
@@ -240,6 +242,7 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
         vim_modal_input: false,
         vim_langmap: { д: "l" },
         vim_line_motions: "display",
+        vim_showbreak: true,
       })
       const server = JSON.parse(yield* fs.readFileString(source))
       expect(server.theme).toBeUndefined()

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -58,6 +58,7 @@ import type { CopyModeAdapter } from "../vim/copy-adapter"
 import { clearSelection } from "../vim/vim-motions"
 import { usePromptVim } from "./vim"
 import { emptyRows } from "./empty-selection"
+import { drawShowbreak } from "./showbreak"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "../../util/provider-origin"
 import {
   OPENCODE_BASE_MODE,
@@ -1945,6 +1946,7 @@ export function Prompt(props: PromptProps) {
                   const render = textarea.render.bind(textarea)
                   textarea.render = (buffer, deltaTime) => {
                     render(buffer, deltaTime)
+                    drawShowbreak(buffer, textarea, cfg.vim_showbreak ?? false, theme.textMuted, theme.backgroundElement)
 
                     const visual = vimState.isVisual()
                     const selectionBg = textarea.selectionBg ?? textarea.textColor

--- a/packages/tui/src/component/prompt/showbreak.ts
+++ b/packages/tui/src/component/prompt/showbreak.ts
@@ -1,0 +1,23 @@
+import type { OptimizedBuffer, RGBA, TextareaRenderable } from "@opentui/core"
+
+const SHOWBREAK_MARKER = "↪ "
+
+type ShowbreakTarget = Pick<TextareaRenderable, "x" | "y" | "height" | "scrollY" | "lineInfo">
+
+export function showbreakRows(info: { lineWraps: number[] }, scroll: number, height: number) {
+  const end = Math.min(scroll + height, info.lineWraps.length)
+  return info.lineWraps.slice(scroll, end).flatMap((wrap, row) => (wrap > 0 ? [row] : []))
+}
+
+export function drawShowbreak(
+  buffer: Pick<OptimizedBuffer, "drawText">,
+  target: ShowbreakTarget,
+  enabled: boolean,
+  foreground: RGBA,
+  background: RGBA,
+) {
+  if (!enabled || target.x < 2) return
+  for (const row of showbreakRows(target.lineInfo, target.scrollY, target.height)) {
+    buffer.drawText(SHOWBREAK_MARKER, target.x - 2, target.y + row, foreground, background)
+  }
+}

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -44,6 +44,10 @@ export const VimLineMotions = Schema.Literals(["logical", "display_vertical", "d
 })
 export type VimLineMotions = Schema.Schema.Type<typeof VimLineMotions>
 
+export const VimShowbreak = Schema.Boolean.annotate({
+  description: "Show a marker in the prompt gutter for wrapped rows",
+})
+
 const PromptMaxHeight = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1), Schema.isLessThanOrEqualTo(50)).annotate({
   description: "Maximum number of rows the prompt input expands to",
 })
@@ -96,6 +100,7 @@ export const Info = Schema.Struct({
   }),
   vim_langmap: Schema.optional(VimLangmap),
   vim_line_motions: Schema.optional(VimLineMotions),
+  vim_showbreak: Schema.optional(VimShowbreak),
   vim_escape_sequence: Schema.optional(Schema.String.check(Schema.isPattern(/^.{2}$/u))).annotate({
     description: "Two-character sequence to exit vim insert mode (e.g., 'jk')",
   }),
@@ -103,7 +108,7 @@ export const Info = Schema.Struct({
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
-export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse"> & {
+export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse" | "vim_showbreak"> & {
   attention: {
     enabled: boolean
     notifications: boolean
@@ -115,6 +120,7 @@ export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | 
   keybinds: TuiKeybind.BindingLookupView
   leader_timeout: number
   mouse: boolean
+  vim_showbreak: boolean
 }
 
 export const ResolveOptions = Schema.Struct({
@@ -152,6 +158,7 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
     mouse: input.mouse ?? true,
     vim_modal_input: input.vim_modal_input ?? true,
     vim_line_motions: input.vim_line_motions ?? "logical",
+    vim_showbreak: input.vim_showbreak ?? false,
   }
 }
 

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -44,6 +44,8 @@ test("validates config constraints", () => {
     keybinds: { "vim.normal": { input_move_down: "j" } },
   })
   expect(() => decodeInfo({ keybinds: { "vim.normal": "j" } })).toThrow()
+  expect(decodeInfo({ vim_showbreak: true })).toEqual({ vim_showbreak: true })
+  expect(() => decodeInfo({ vim_showbreak: "↪ " })).toThrow()
 })
 
 test("drops unknown keybinds without hiding invalid known scopes", () => {
@@ -70,6 +72,7 @@ test("resolves host-neutral defaults", () => {
   })
   expect(config.leader_timeout).toBe(LeaderTimeoutDefault)
   expect(config.mouse).toBe(true)
+  expect(config.vim_showbreak).toBe(false)
   expect(config.keybinds.has("terminal.suspend")).toBe(true)
   expect(config.keybinds.has("session.list")).toBe(true)
 })

--- a/packages/tui/test/prompt-showbreak.test.ts
+++ b/packages/tui/test/prompt-showbreak.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test"
+import { BoxRenderable, RGBA, TextareaRenderable } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+import { drawShowbreak, showbreakRows } from "../src/component/prompt/showbreak"
+
+describe("prompt showbreak", () => {
+  test("finds visible wrapped continuation rows", () => {
+    const info = { lineWraps: [0, 1, 2, 0, 1] }
+
+    expect(showbreakRows(info, 0, 5)).toEqual([1, 2, 4])
+    expect(showbreakRows(info, 2, 2)).toEqual([0])
+  })
+
+  test("draws the marker right-aligned in the prompt padding", () => {
+    const calls: Array<{ text: string; x: number; y: number }> = []
+    const buffer = {
+      drawText(text: string, x: number, y: number) {
+        calls.push({ text, x, y })
+      },
+    }
+    const target = {
+      x: 5,
+      y: 10,
+      height: 3,
+      scrollY: 1,
+      lineInfo: {
+        lineStartCols: [0, 20, 40, 0],
+        lineWidthCols: [20, 20, 20, 4],
+        lineWidthColsMax: 60,
+        lineSources: [0, 0, 0, 1],
+        lineWraps: [0, 1, 2, 0],
+      },
+    }
+    const color = RGBA.fromInts(255, 255, 255)
+
+    drawShowbreak(buffer as any, target as any, true, color, color)
+
+    expect(calls).toEqual([
+      { text: "↪ ", x: 3, y: 10 },
+      { text: "↪ ", x: 3, y: 11 },
+    ])
+  })
+
+  test("renders in padding without changing prompt text", async () => {
+    const setup = await createTestRenderer({ width: 24, height: 5, useThread: false })
+    const box = new BoxRenderable(setup.renderer as any, { width: 22, height: 3, paddingLeft: 2 })
+    const textarea = new TextareaRenderable(setup.renderer as any, { width: 20, height: 3, wrapMode: "word" })
+    box.add(textarea)
+    setup.renderer.root.add(box)
+    textarea.setText("A".repeat(45))
+    const original = textarea.plainText
+    const render = textarea.render.bind(textarea)
+    const color = RGBA.fromInts(128, 128, 128)
+    let enabled = true
+    textarea.render = (buffer, deltaTime) => {
+      render(buffer, deltaTime)
+      drawShowbreak(buffer, textarea, enabled, color, color)
+    }
+
+    try {
+      await setup.renderOnce()
+      const lines = setup.captureCharFrame().split("\n")
+      expect(lines[0]?.startsWith("  A")).toBe(true)
+      expect(lines[1]?.startsWith("↪ A")).toBe(true)
+      expect(lines[2]?.startsWith("↪ A")).toBe(true)
+      expect(textarea.plainText).toBe(original)
+
+      enabled = false
+      await setup.renderOnce()
+      expect(setup.captureCharFrame()).not.toContain("↪")
+
+      enabled = true
+      textarea.setText("short")
+      await setup.renderOnce()
+      expect(setup.captureCharFrame()).not.toContain("↪")
+    } finally {
+      setup.renderer.destroy()
+    }
+  })
+
+  test("uses the textarea's visual scroll offset", async () => {
+    const setup = await createTestRenderer({ width: 24, height: 4, useThread: false })
+    const box = new BoxRenderable(setup.renderer as any, { width: 22, height: 2, paddingLeft: 2 })
+    const textarea = new TextareaRenderable(setup.renderer as any, { width: 20, height: 2, wrapMode: "word" })
+    box.add(textarea)
+    setup.renderer.root.add(box)
+    textarea.setText("A".repeat(60))
+    textarea.cursorOffset = 59
+    const render = textarea.render.bind(textarea)
+    const color = RGBA.fromInts(128, 128, 128)
+    textarea.render = (buffer, deltaTime) => {
+      render(buffer, deltaTime)
+      drawShowbreak(buffer, textarea, true, color, color)
+    }
+
+    try {
+      await setup.renderOnce()
+      const lines = setup.captureCharFrame().split("\n")
+      expect(textarea.scrollY).toBe(1)
+      expect(lines[0]?.startsWith("↪ A")).toBe(true)
+      expect(lines[1]?.startsWith("↪ A")).toBe(true)
+    } finally {
+      setup.renderer.destroy()
+    }
+  })
+
+  test("does not draw when disabled or padding is unavailable", () => {
+    let calls = 0
+    const buffer = { drawText: () => calls++ }
+    const target = {
+      x: 5,
+      y: 0,
+      height: 1,
+      scrollY: 0,
+      lineInfo: { lineWraps: [1] },
+    }
+    const color = RGBA.fromInts(255, 255, 255)
+
+    drawShowbreak(buffer as any, target as any, false, color, color)
+    drawShowbreak(buffer as any, { ...target, x: 1 } as any, true, color, color)
+
+    expect(calls).toBe(0)
+  })
+})


### PR DESCRIPTION
Adds option `vim_showbreak`, that displays a marker beside wrapped prompt rows.

<img width="1073" height="262" alt="Screenshot 2026-07-11 at 7 22 23 PM" src="https://github.com/user-attachments/assets/7176c1bd-9fef-4321-9069-2d7ace36b713" />
