### PR TITLE
fix: refer to "ocv" instead of "opencode" in session continue messages and help text

### DIFF
--- a/packages/opencode/src/cli/cmd/run/splash.ts
+++ b/packages/opencode/src/cli/cmd/run/splash.ts
@@ -234,7 +234,7 @@ function build(input: SplashWriterInput, kind: "entry" | "exit", ctx: Scrollback
       lines,
       body_left + label.length,
       top + 1,
-      `opencode --mini -s ${meta.session_id}`,
+      `ocv --mini -s ${meta.session_id}`,
       right,
       undefined,
       TextAttributes.BOLD,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -35,7 +35,7 @@ const args = hideBin(process.argv)
 
 function show(out: string) {
   const text = out.trimStart()
-  if (!text.startsWith("opencode ")) {
+  if (!text.startsWith("ocv ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
     process.stderr.write(text + EOL)
     return
@@ -45,7 +45,7 @@ function show(out: string) {
 
 const cli = yargs(args)
   .parserConfiguration({ "populate--": true })
-  .scriptName("opencode")
+  .scriptName("ocv")
   .wrap(100)
   .help("help", "show help")
   .alias("help", "h")

--- a/packages/tui/src/util/presentation.ts
+++ b/packages/tui/src/util/presentation.ts
@@ -32,7 +32,7 @@ export function sessionEpilogue(input: { title: string; sessionID?: string }) {
     ...wordmark("  "),
     "",
     `  ${weak("Session")}${bold}${input.title}${reset}`,
-    `  ${weak("Continue")}${bold}opencode -s ${input.sessionID}${reset}`,
+    `  ${weak("Continue")}${bold}ocv -s ${input.sessionID}${reset}`,
     "",
   ].join("\n")
 }

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -119,7 +119,7 @@ test("app.exit prints the session epilogue after scoped cleanup", async () => {
     await task
 
     expect(stdout).toContain("Demo session")
-    expect(stdout).toContain("opencode -s dummy")
+    expect(stdout).toContain("ocv -s dummy")
   } finally {
     process.stdout.write = originalWrite
     if (!setup.renderer.isDestroyed) setup.renderer.destroy()

--- a/packages/tui/test/util/presentation.test.ts
+++ b/packages/tui/test/util/presentation.test.ts
@@ -4,5 +4,5 @@ import { sessionEpilogue } from "../../src/util/presentation"
 test("formats session continuation summary", () => {
   const epilogue = sessionEpilogue({ title: "A session", sessionID: "ses_123" })
   expect(epilogue).toContain("A session")
-  expect(epilogue).toContain("opencode -s ses_123")
+  expect(epilogue).toContain("ocv -s ses_123")
 })


### PR DESCRIPTION
The `opencode -s ...` problem has been biting me since I started using opencode-vim - every few weeks I will absent-mindedly forget and copy-paste the "opencode -s ses_..." to reload a session with new config (or whatever), and then be confused for a while when things aren't quite the same as they were... because I should have done "ocv -s ses_..." instead.  This fixes that problem by adjusting the message to instead say `ocv -s ...`.  It also updates the `ocv help` and `ocv --help` output so that the commands are listed as "ocv foo", rather than "opencode foo", which is another source of potential confusion.